### PR TITLE
Report 'return to normal' on transition from unstable to success

### DIFF
--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -65,7 +65,9 @@ public class ActiveNotifier implements FineGrainedNotifier {
         if ((result == Result.ABORTED && jobProperty.getNotifyAborted())
                 || (result == Result.FAILURE && jobProperty.getNotifyFailure())
                 || (result == Result.NOT_BUILT && jobProperty.getNotifyNotBuilt())
-                || (result == Result.SUCCESS && previousResult == Result.FAILURE && jobProperty.getNotifyBackToNormal())
+                || (result == Result.SUCCESS
+                		&& (previousResult == Result.FAILURE || previousResult == Result.UNSTABLE)
+                		&& jobProperty.getNotifyBackToNormal())
                 || (result == Result.SUCCESS && jobProperty.getNotifySuccess())
                 || (result == Result.UNSTABLE && jobProperty.getNotifyUnstable())) {
             getSlack(r).publish(getBuildStatusMessage(r), getBuildColor(r));


### PR DESCRIPTION
Hi,

It would be good to report 'return to normal' notifications when builds recover from 'unstable' state as well as 'failed' state.

What do you think?

Tim