### PR TITLE
add fallback to attachment (used by notifications)

### DIFF
--- a/src/main/java/jenkins/plugins/slack/StandardSlackService.java
+++ b/src/main/java/jenkins/plugins/slack/StandardSlackService.java
@@ -52,6 +52,7 @@ public class StandardSlackService implements SlackService {
                 fields.put(field);
 
                 JSONObject attachment = new JSONObject();
+                attachment.put("fallback", message);
                 attachment.put("color", color);
                 attachment.put("fields", fields);
                 JSONArray attachments = new JSONArray();


### PR DESCRIPTION
The colors added in #20 resulted in 'empty' notifications. Setting the 'fallback' field in the attachment object fixes this. 