### PR TITLE
Include test summary in build notifications

### DIFF
--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -47,7 +47,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
             message.append(cause.getShortDescription());
             notifyStart(build, message.appendOpenLink().toString());
         } else {
-            notifyStart(build, getBuildStatusMessage(build));
+            notifyStart(build, getBuildStatusMessage(build, false));
         }
     }
 

--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -5,6 +5,8 @@ import hudson.model.*;
 import hudson.scm.ChangeLogSet;
 import hudson.scm.ChangeLogSet.AffectedFile;
 import hudson.scm.ChangeLogSet.Entry;
+import hudson.tasks.test.AbstractTestResultAction;
+
 import org.apache.commons.lang.StringUtils;
 
 import java.util.HashSet;
@@ -118,7 +120,8 @@ public class ActiveNotifier implements FineGrainedNotifier {
         MessageBuilder message = new MessageBuilder(notifier, r);
         message.appendStatusMessage();
         message.appendDuration();
-        return message.appendOpenLink().toString();
+        message.appendOpenLink();
+        return message.appendTestSummary().toString();
     }
 
     public static class MessageBuilder {
@@ -181,6 +184,23 @@ public class ActiveNotifier implements FineGrainedNotifier {
         public MessageBuilder appendDuration() {
             message.append(" after ");
             message.append(build.getDurationString());
+            return this;
+        }
+
+        public MessageBuilder appendTestSummary(){
+            AbstractTestResultAction<?> action = this.build
+                    .getAction(AbstractTestResultAction.class);
+            if (action != null) {
+                int total = action.getTotalCount();
+                int failed = action.getFailCount();
+                int skipped = action.getSkipCount();
+                message.append("\nTest Status:\n");
+                message.append("\tPassed: " + (total - failed - skipped));
+                message.append(", Failed: " + failed);
+                message.append(", Skipped: " + skipped);
+            } else {
+                message.append("\nNo Tests found.");
+            }
             return this;
         }
 

--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -70,7 +70,8 @@ public class ActiveNotifier implements FineGrainedNotifier {
                 || (result == Result.SUCCESS && previousResult == Result.FAILURE && jobProperty.getNotifyBackToNormal())
                 || (result == Result.SUCCESS && jobProperty.getNotifySuccess())
                 || (result == Result.UNSTABLE && jobProperty.getNotifyUnstable())) {
-            getSlack(r).publish(getBuildStatusMessage(r), getBuildColor(r));
+            getSlack(r).publish(getBuildStatusMessage(r, jobProperty.includeTestSummary()),
+                    getBuildColor(r));
         }
     }
 
@@ -116,11 +117,14 @@ public class ActiveNotifier implements FineGrainedNotifier {
         }
     }
 
-    String getBuildStatusMessage(AbstractBuild r) {
+    String getBuildStatusMessage(AbstractBuild r, boolean includeTestSummary) {
         MessageBuilder message = new MessageBuilder(notifier, r);
         message.appendStatusMessage();
         message.appendDuration();
         message.appendOpenLink();
+        if (!includeTestSummary){
+            return message.toString();
+        }
         return message.appendTestSummary().toString();
     }
 

--- a/src/main/java/jenkins/plugins/slack/SlackNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/SlackNotifier.java
@@ -157,6 +157,7 @@ public class SlackNotifier extends Notifier {
         private boolean notifyUnstable;
         private boolean notifyFailure;
         private boolean notifyBackToNormal;
+        private boolean includeTestSummary;
 
 
         @DataBoundConstructor
@@ -167,7 +168,8 @@ public class SlackNotifier extends Notifier {
                                   boolean notifyNotBuilt,
                                   boolean notifySuccess,
                                   boolean notifyUnstable,
-                                  boolean notifyBackToNormal) {
+                                  boolean notifyBackToNormal,
+                                  boolean includeTestSummary) {
             this.room = room;
             this.startNotification = startNotification;
             this.notifyAborted = notifyAborted;
@@ -176,6 +178,7 @@ public class SlackNotifier extends Notifier {
             this.notifySuccess = notifySuccess;
             this.notifyUnstable = notifyUnstable;
             this.notifyBackToNormal = notifyBackToNormal;
+            this.includeTestSummary = includeTestSummary;
         }
 
         @Exported
@@ -232,6 +235,11 @@ public class SlackNotifier extends Notifier {
             return notifyBackToNormal;
         }
 
+        @Exported
+        public boolean includeTestSummary() {
+            return includeTestSummary;
+        }
+
         @Extension
         public static final class DescriptorImpl extends JobPropertyDescriptor {
             public String getDisplayName() {
@@ -252,7 +260,8 @@ public class SlackNotifier extends Notifier {
                         sr.getParameter("slackNotifyNotBuilt") != null,
                         sr.getParameter("slackNotifySuccess") != null,
                         sr.getParameter("slackNotifyUnstable") != null,
-                        sr.getParameter("slackNotifyBackToNormal") != null);
+                        sr.getParameter("slackNotifyBackToNormal") != null,
+                        sr.getParameter("includeTestSummary") != null);
             }
         }
     }

--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/SlackJobProperty/config.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/SlackJobProperty/config.jelly
@@ -33,6 +33,9 @@
             <f:checkbox name="slackNotifyBackToNormal" value="true" checked="${instance.getNotifyBackToNormal()}"/>
         </f:entry>
 
+        <f:entry title="Include Test Summary">
+            <f:checkbox name="includeTestSummary" value="true" checked="${instance.includeTestSummary()}"/>
+        </f:entry>
     </f:section>
 
 </j:jelly>


### PR DESCRIPTION
Include test summary in build notification. A checkbox is added to build settings page which can be used to specify whether to include test summary or not. If enabled and no tests are found, a "No Tests found" message is appended.

![screenshot from 2014-10-19 21 03 55](https://cloud.githubusercontent.com/assets/1310524/4696484/5b17841e-5811-11e4-8136-ff67f5b3d2cc.png)
