### PR TITLE
improve 'started' message with proper cause

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.447</version>
+        <version>1.567</version>
     </parent>
 
     <artifactId>slack</artifactId>


### PR DESCRIPTION
Before, the started message would say the build had been 'started
by changes ...' if a user started a build when there were changes
to be pulled in.

Now if a user starts the build, it will always say 'started by user',
but if a user didn't start the build, it will still show the changes.