### PR TITLE
Make start notifications use the color of the last build's result

### DIFF
--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -52,7 +52,11 @@ public class ActiveNotifier implements FineGrainedNotifier {
     private void notifyStart(AbstractBuild build, String message) {
         AbstractProject<?, ?> project = build.getProject();
         AbstractBuild<?, ?> previousBuild = project.getLastBuild().getPreviousBuild();
-        getSlack(build).publish(message, getBuildColor(previousBuild));
+        if (previousBuild == null) {
+           getSlack(build).publish(message, "good");
+        } else {
+           getSlack(build).publish(message, getBuildColor(previousBuild));
+        }
     }
 
     public void finalized(AbstractBuild r) {

--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -50,7 +50,9 @@ public class ActiveNotifier implements FineGrainedNotifier {
     }
 
     private void notifyStart(AbstractBuild build, String message) {
-        getSlack(build).publish(message, "good");
+        AbstractProject<?, ?> project = build.getProject();
+        AbstractBuild<?, ?> previousBuild = project.getLastBuild().getPreviousBuild();
+        getSlack(build).publish(message, getBuildColor(previousBuild));
     }
 
     public void finalized(AbstractBuild r) {


### PR DESCRIPTION
We've found the notify start alert more useful when the color used is the color of the last build, ie. when the failing build starts it notifies that it's red. Figured I'd pull and see if you wanted to include it in mainline.