### PR TITLE
Issue #39: if option is active, the list of commits is shown...

### DIFF
--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -91,10 +91,9 @@ public class ActiveNotifier implements FineGrainedNotifier {
                 || (result == Result.UNSTABLE && jobProperty.getNotifyUnstable())) {
             getSlack(r).publish(getBuildStatusMessage(r, jobProperty.includeTestSummary()),
                     getBuildColor(r));
-        }
-        if (result == Result.SUCCESS && jobProperty.getNotifySuccess()
-                && jobProperty.getShowCommitList()) {
-            getSlack(r).publish(getCommitList(r), "good");
+            if (jobProperty.getShowCommitList()) {
+                getSlack(r).publish(getCommitList(r), getBuildColor(r));
+            }
         }
     }
 


### PR DESCRIPTION
... after ANY build (as opposed to only successful builds previously)