### PR TITLE
Move test connection button to advanced section

### DIFF
--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/SlackJobProperty/config.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/SlackJobProperty/config.jelly
@@ -1,5 +1,4 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-
     <f:section title="Slack Notifications">
         <f:entry title="Notify Build Start">
             <f:checkbox name="slackStartNotification" value="true" checked="${instance.getStartNotification()}"/>
@@ -52,10 +51,9 @@
             <f:entry title="Project Channel" help="${rootURL}/plugin/slack/help-projectConfig-slackRoom.html">
                 <f:textbox name="slackProjectRoom" value="${instance.getRoom()}"/>
             </f:entry>
+            <f:validateButton
+                title="${%Test Connection}" progress="${%Testing...}"
+                method="testConnection" with="slackTeamDomain,slackToken,slackProjectRoom" />
         </f:advanced>
-        <f:validateButton
-            title="${%Test Connection}" progress="${%Testing...}"
-            method="testConnection" with="slackTeamDomain,slackToken,slackProjectRoom" />
     </f:section>
-
 </j:jelly>


### PR DESCRIPTION
It makes sense to group the test connection button with the settings it is actually testing in the advanced section of the slack job config.

Please peer review my change.