### PR TITLE
search upstream causes when gathering commit list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.447</version>
+        <version>1.567</version>
     </parent>
 
     <artifactId>slack</artifactId>

--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -4,7 +4,9 @@ import hudson.Util;
 import hudson.model.Result;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
+import hudson.model.Cause;
 import hudson.model.CauseAction;
+import hudson.model.Hudson;
 import hudson.model.Run;
 import hudson.scm.ChangeLogSet;
 import hudson.scm.ChangeLogSet.AffectedFile;
@@ -132,10 +134,6 @@ public class ActiveNotifier implements FineGrainedNotifier {
     }
 
     String getCommitList(AbstractBuild r) {
-        if (!r.hasChangeSetComputed()) {
-            logger.info("No commits.");
-            return "No Changes.";
-        }
         ChangeLogSet changeSet = r.getChangeSet();
         List<Entry> entries = new LinkedList<Entry>();
         for (Object o : changeSet.getItems()) {
@@ -145,7 +143,15 @@ public class ActiveNotifier implements FineGrainedNotifier {
         }
         if (entries.isEmpty()) {
             logger.info("Empty change...");
-            return "No Changes.";
+            Cause.UpstreamCause c = (Cause.UpstreamCause)r.getCause(Cause.UpstreamCause.class);
+            if (c == null) {
+                return "No Changes.";
+            }
+            String upProjectName = c.getUpstreamProject();
+            int buildNumber = c.getUpstreamBuild();
+            AbstractProject project = Hudson.getInstance().getItemByFullName(upProjectName, AbstractProject.class);
+            AbstractBuild upBuild = (AbstractBuild)project.getBuildByNumber(buildNumber);
+            return getCommitList(upBuild);
         }
         Set<String> commits = new HashSet<String>();
         for (Entry entry : entries) {


### PR DESCRIPTION
The "r.hasChangeSetComputed()" check is superfluous and looks wrong, so remove it:
http://javadoc.jenkins-ci.org/hudson/model/AbstractBuild.html#hasChangeSetComputed()

Before, if a downstream change was triggered by a commit and the
"Show Commit List with Titles and Authors" option was enabled, the downstream
change would notify "No Changes.".
Now, the downstream change will notify with the list of changes from an
upstream cause that has changes. If there are no upstream changes, it
still notifies "No Changes.".