### PR TITLE
Change .getPreviousBuild() to allow for higher concurrency

### DIFF
--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -58,7 +58,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
 
     private void notifyStart(AbstractBuild build, String message) {
         AbstractProject<?, ?> project = build.getProject();
-        AbstractBuild<?, ?> previousBuild = project.getLastBuild().getPreviousBuild();
+        AbstractBuild<?, ?> previousBuild = project.getLastBuild().getPreviousCompletedBuild();
         if (previousBuild == null) {
             getSlack(build).publish(message, "good");
         } else {
@@ -79,7 +79,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
         Result result = r.getResult();
         AbstractBuild<?, ?> previousBuild = project.getLastBuild();
         do {
-            previousBuild = previousBuild.getPreviousBuild();
+            previousBuild = previousBuild.getPreviousCompletedBuild();
         } while (previousBuild != null && previousBuild.getResult() == Result.ABORTED);
         Result previousResult = (previousBuild != null) ? previousBuild.getResult() : Result.SUCCESS;
         if ((result == Result.ABORTED && jobProperty.getNotifyAborted())


### PR DESCRIPTION
Jenkins changed getPreviousBuild() to halt jobs if a previous
build hasn't finished, meaning jobs of variable runtime end up
being serialized:

https://issues.jenkins-ci.org/browse/JENKINS-9913?focusedCommentId=184188&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-184188

This change switches to the latest completed build, allowing
this plugin to work with jobs of variable length.