### PR TITLE
Option to add a custom message

### DIFF
--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -46,12 +46,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
     }
 
     public void started(AbstractBuild build) {
-/*
-        String changes = getChanges(build);
-        CauseAction cause = build.getAction(CauseAction.class);
-        AbstractProject<?, ?> project = build.getProject();
-        SlackNotifier.SlackJobProperty jobProperty = project.getProperty(SlackNotifier.SlackJobProperty.class);
-*/
+        
         AbstractProject<?, ?> project = build.getProject();
         SlackNotifier.SlackJobProperty jobProperty = project.getProperty(SlackNotifier.SlackJobProperty.class);
 

--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -1,5 +1,6 @@
 package jenkins.plugins.slack;
 
+import hudson.EnvVars;
 import hudson.Util;
 import hudson.model.Result;
 import hudson.model.AbstractBuild;
@@ -289,17 +290,16 @@ public class ActiveNotifier implements FineGrainedNotifier {
             AbstractProject<?, ?> project = build.getProject();
             String customMessage = Util.fixEmpty(project.getProperty(SlackNotifier.SlackJobProperty.class)
                     .getCustomMessage());
-            Map<String, String> buildVariables = new HashMap();
-            buildVariables.putAll(build.getBuildVariables());
+            EnvVars envVars = new EnvVars();
             try {
-                buildVariables.putAll(build.getEnvironment(new LogTaskListener(logger, INFO)));
+                envVars = build.getEnvironment(new LogTaskListener(logger, INFO));
             } catch (IOException e) {
                 logger.log(SEVERE, e.getMessage(), e);
             } catch (InterruptedException e) {
                 logger.log(SEVERE, e.getMessage(), e);
             }
             message.append("\n");
-            message.append(replaceMacro(customMessage, new VariableResolver.ByMap<String>(buildVariables)));
+            message.append(envVars.expand(customMessage));
             return this;
         }
 

--- a/src/main/java/jenkins/plugins/slack/SlackNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/SlackNotifier.java
@@ -180,9 +180,9 @@ public class SlackNotifier extends Notifier {
         }
 
         public FormValidation doTestConnection(@QueryParameter("slackTeamDomain") final String teamDomain,
-                @QueryParameter("slackToken") final String authToken,
-                @QueryParameter("slackRoom") final String room,
-                @QueryParameter("slackBuildServerUrl") final String buildServerUrl) throws FormException {
+                                               @QueryParameter("slackToken") final String authToken,
+                                               @QueryParameter("slackRoom") final String room,
+                                               @QueryParameter("slackBuildServerUrl") final String buildServerUrl) throws FormException {
             try {
                 SlackService testSlackService = new StandardSlackService(teamDomain, authToken, room);
                 String message = "Slack/Jenkins plugin: you're all set on " + buildServerUrl;
@@ -209,21 +209,25 @@ public class SlackNotifier extends Notifier {
         private boolean notifyRepeatedFailure;
         private boolean includeTestSummary;
         private boolean showCommitList;
+        private boolean includeCustomMessage;
+        private String customMessage;
 
         @DataBoundConstructor
         public SlackJobProperty(String teamDomain,
-                String token,
-                String room,
-                boolean startNotification,
-                boolean notifyAborted,
-                boolean notifyFailure,
-                boolean notifyNotBuilt,
-                boolean notifySuccess,
-                boolean notifyUnstable,
-                boolean notifyBackToNormal,
-                boolean notifyRepeatedFailure,
-                boolean includeTestSummary,
-                boolean showCommitList) {
+                                String token,
+                                String room,
+                                boolean startNotification,
+                                boolean notifyAborted,
+                                boolean notifyFailure,
+                                boolean notifyNotBuilt,
+                                boolean notifySuccess,
+                                boolean notifyUnstable,
+                                boolean notifyBackToNormal,
+                                boolean notifyRepeatedFailure,
+                                boolean includeTestSummary,
+                                boolean showCommitList,
+                                boolean includeCustomMessage,
+                                String customMessage) {
             this.teamDomain = teamDomain;
             this.token = token;
             this.room = room;
@@ -237,6 +241,8 @@ public class SlackNotifier extends Notifier {
             this.notifyRepeatedFailure = notifyRepeatedFailure;
             this.includeTestSummary = includeTestSummary;
             this.showCommitList = showCommitList;
+            this.includeCustomMessage = includeCustomMessage;
+            this.customMessage = customMessage;
         }
 
         @Exported
@@ -319,6 +325,16 @@ public class SlackNotifier extends Notifier {
             return notifyRepeatedFailure;
         }
 
+        @Exported
+        public boolean includeCustomMessage() {
+            return includeCustomMessage;
+        }
+
+        @Exported
+        public String getCustomMessage() {
+            return customMessage;
+        }
+
         @Extension
         public static final class DescriptorImpl extends JobPropertyDescriptor {
 
@@ -346,12 +362,14 @@ public class SlackNotifier extends Notifier {
                         sr.getParameter("slackNotifyBackToNormal") != null,
                         sr.getParameter("slackNotifyRepeatedFailure") != null,
                         sr.getParameter("includeTestSummary") != null,
-                        sr.getParameter("slackShowCommitList") != null);
+                        sr.getParameter("slackShowCommitList") != null,
+                        sr.getParameter("includeCustomMessage") != null,
+                        sr.getParameter("customMessage"));
             }
 
             public FormValidation doTestConnection(@QueryParameter("slackTeamDomain") final String teamDomain,
-                    @QueryParameter("slackToken") final String authToken,
-                    @QueryParameter("slackProjectRoom") final String room) throws FormException {
+                                                   @QueryParameter("slackToken") final String authToken,
+                                                   @QueryParameter("slackProjectRoom") final String room) throws FormException {
                 try {
                     SlackService testSlackService = new StandardSlackService(teamDomain, authToken, room);
                     String message = "Slack/Jenkins plugin: you're all set.";

--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/SlackJobProperty/config.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/SlackJobProperty/config.jelly
@@ -36,6 +36,12 @@
                 <f:checkbox name="includeTestSummary" value="true" checked="${instance.includeTestSummary()}"/>
             </f:entry>
 
+            <f:optionalBlock name="includeCustomMessage" title="Include Custom Message" checked="${instance.includeCustomMessage()}">
+                <f:entry title="Custom Message" help="${rootURL}/plugin/slack/help-projectConfig-slackCustomMessage.html">
+                    <f:textbox name="customMessage" value="${instance.getCustomMessage()}"/>
+                </f:entry>
+            </f:optionalBlock>
+
             <f:entry title="Show Commit List with Titles and Authors">
                 <f:checkbox name="slackShowCommitList" value="true" checked="${instance.getShowCommitList()}"/>
             </f:entry>

--- a/src/main/webapp/help-projectConfig-slackCustomMessage.html
+++ b/src/main/webapp/help-projectConfig-slackCustomMessage.html
@@ -1,0 +1,5 @@
+<div>
+  <p>
+    Enter a custom message that will be included with the notifications. Include build variables in the form <em>$VAR_NAME</em>.
+  </p>
+</div>


### PR DESCRIPTION
Related to issue #49.

Option to include a custom message in the advanced section of the config. Resolves build variables. We use this mostly to include maven variables as shown in the screen shots.    

Config:
![screen shot 2015-04-07 at 9 08 08 pm](https://cloud.githubusercontent.com/assets/6313470/7031812/990ba2ea-dd6e-11e4-8bc9-971f7a69c229.png)

Outcome:
![screen shot 2015-04-07 at 9 40 39 pm](https://cloud.githubusercontent.com/assets/6313470/7031851/d06d0364-dd6e-11e4-8b0f-fda24be81671.png)
