### PR TITLE
Improvements to test connection

### DIFF
--- a/src/main/java/jenkins/plugins/slack/SlackNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/SlackNotifier.java
@@ -186,8 +186,8 @@ public class SlackNotifier extends Notifier {
             try {
                 SlackService testSlackService = new StandardSlackService(teamDomain, authToken, room);
                 String message = "Slack/Jenkins plugin: you're all set on " + buildServerUrl;
-                testSlackService.publish(message, "green");
-                return FormValidation.ok("Success");
+                boolean success = testSlackService.publish(message, "green");
+                return success ? FormValidation.ok("Success") : FormValidation.error("Failure");
             } catch (Exception e) {
                 return FormValidation.error("Client error : " + e.getMessage());
             }
@@ -355,8 +355,8 @@ public class SlackNotifier extends Notifier {
                 try {
                     SlackService testSlackService = new StandardSlackService(teamDomain, authToken, room);
                     String message = "Slack/Jenkins plugin: you're all set.";
-                    testSlackService.publish(message, "green");
-                    return FormValidation.ok("Success");
+                    boolean success = testSlackService.publish(message, "green");
+                    return success ? FormValidation.ok("Success") : FormValidation.error("Failure");
                 } catch (Exception e) {
                     return FormValidation.error("Client error : " + e.getMessage());
                 }

--- a/src/main/java/jenkins/plugins/slack/SlackService.java
+++ b/src/main/java/jenkins/plugins/slack/SlackService.java
@@ -1,7 +1,7 @@
 package jenkins.plugins.slack;
 
 public interface SlackService {
-    void publish(String message);
+    boolean publish(String message);
 
-    void publish(String message, String color);
+    boolean publish(String message, String color);
 }

--- a/src/main/java/jenkins/plugins/slack/StandardSlackService.java
+++ b/src/main/java/jenkins/plugins/slack/StandardSlackService.java
@@ -31,11 +31,11 @@ public class StandardSlackService implements SlackService {
         this.roomIds = roomId.split("[,; ]+");
     }
 
-    public void publish(String message) {
-        publish(message, "warning");
+    public boolean publish(String message) {
+        return publish(message, "warning");
     }
 
-    public void publish(String message, String color) {
+    public boolean publish(String message, String color) {
         for (String roomId : roomIds) {
             String url = "https://" + teamDomain + "." + host + "/services/hooks/jenkins-ci?token=" + token;
             logger.info("Posting: to " + roomId + " on " + teamDomain + " using " + url +": " + message + " " + color);
@@ -67,14 +67,18 @@ public class StandardSlackService implements SlackService {
                 String response = post.getResponseBodyAsString();
                 if(responseCode != HttpStatus.SC_OK) {
                     logger.log(Level.WARNING, "Slack post may have failed. Response: " + response);
+                    return false;
                 }
+                return true;
             } catch (Exception e) {
                 logger.log(Level.WARNING, "Error posting to Slack", e);
+                return false;
             } finally {
                 logger.info("Posting succeeded");
                 post.releaseConnection();
             }
         }
+        return false;
     }
 
     private HttpClient getHttpClient() {


### PR DESCRIPTION
Addresses issue #51. 

When testing a connection, will only state success if a notification is successfully sent. While this could be further improved to provide the actual reason for failure, this change should at least mean that the response from testing the connection is accurate. 