### PR TITLE
add unit tests for doTestConnection method

### DIFF
--- a/src/main/java/jenkins/plugins/slack/SlackNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/SlackNotifier.java
@@ -174,6 +174,10 @@ public class SlackNotifier extends Notifier {
             return super.configure(sr, formData);
         }
 
+        SlackService getSlackService(final String teamDomain, final String authToken, final String room) {
+            return new StandardSlackService(teamDomain, authToken, room);
+        }
+
         @Override
         public String getDisplayName() {
             return "Slack Notifications";
@@ -184,7 +188,7 @@ public class SlackNotifier extends Notifier {
                 @QueryParameter("slackRoom") final String room,
                 @QueryParameter("slackBuildServerUrl") final String buildServerUrl) throws FormException {
             try {
-                SlackService testSlackService = new StandardSlackService(teamDomain, authToken, room);
+                SlackService testSlackService = getSlackService(teamDomain, authToken, room);
                 String message = "Slack/Jenkins plugin: you're all set on " + buildServerUrl;
                 boolean success = testSlackService.publish(message, "green");
                 return success ? FormValidation.ok("Success") : FormValidation.error("Failure");

--- a/src/test/java/jenkins/plugins/slack/SlackNotifierStub.java
+++ b/src/test/java/jenkins/plugins/slack/SlackNotifierStub.java
@@ -1,0 +1,26 @@
+package jenkins.plugins.slack;
+
+public class SlackNotifierStub extends SlackNotifier {
+
+    public SlackNotifierStub(String teamDomain, String authToken, String room, String buildServerUrl, String sendAs) {
+        super(teamDomain, authToken, room, buildServerUrl, sendAs);
+    }
+
+    public static class DescriptorImplStub extends SlackNotifier.DescriptorImpl {
+
+        private SlackService slackService;
+
+        @Override
+        public synchronized void load() {
+        }
+
+        @Override
+        SlackService getSlackService(final String teamDomain, final String authToken, final String room) {
+            return slackService;
+        }
+
+        public void setSlackService(SlackService slackService) {
+            this.slackService = slackService;
+        }
+    }
+}

--- a/src/test/java/jenkins/plugins/slack/SlackNotifierTest.java
+++ b/src/test/java/jenkins/plugins/slack/SlackNotifierTest.java
@@ -1,0 +1,74 @@
+package jenkins.plugins.slack;
+
+import hudson.model.Descriptor;
+import hudson.util.FormValidation;
+import junit.framework.TestCase;
+import org.junit.Test;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+public class SlackNotifierTest extends TestCase {
+
+    private SlackNotifierStub.DescriptorImplStub descriptor;
+    private SlackServiceStub slackServiceStub;
+    private boolean response;
+    private FormValidation.Kind expectedResult;
+
+    @Before
+    @Override
+    public void setUp() {
+        descriptor = new SlackNotifierStub.DescriptorImplStub();
+    }
+
+    public SlackNotifierTest(SlackServiceStub slackServiceStub, boolean response, FormValidation.Kind expectedResult) {
+        this.slackServiceStub = slackServiceStub;
+        this.response = response;
+        this.expectedResult = expectedResult;
+    }
+
+    @Parameterized.Parameters
+    public static Collection businessTypeKeys() {
+        return Arrays.asList(new Object[][]{
+                {new SlackServiceStub(), true, FormValidation.Kind.OK},
+                {new SlackServiceStub(), false, FormValidation.Kind.ERROR},
+                {null, false, FormValidation.Kind.ERROR}
+        });
+    }
+
+    @Test
+    public void testDoTestConnection() {
+        if (slackServiceStub != null) {
+            slackServiceStub.setResponse(response);
+        }
+        descriptor.setSlackService(slackServiceStub);
+        try {
+            FormValidation result = descriptor.doTestConnection("teamDomain", "authToken", "room", "buildServerUrl");
+            assertEquals(result.kind, expectedResult);
+        } catch (Descriptor.FormException e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    public static class SlackServiceStub implements SlackService {
+
+        private boolean response;
+
+        public boolean publish(String message) {
+            return response;
+        }
+
+        public boolean publish(String message, String color) {
+            return response;
+        }
+
+        public void setResponse(boolean response) {
+            this.response = response;
+        }
+    }
+}


### PR DESCRIPTION
In response to issue #82 I've written some unit tests to provide coverage for a method I modified recently.  In addition, this pr includes a slight change to the SlackNotifier class that allows the call to the publish method to be easily stubbed. Happy to modify this to use a mocking framework if that's the preference. I'll write some more tests once everyone is happy with the approach. 