### PR TITLE
Append custom message to notifyStart message if changes are found

### DIFF
--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -63,7 +63,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
             }
         }
 
-        String changes = getChanges(build);
+        String changes = getChanges(build, notifier.includeCustomMessage());
         if (changes != null) {
             notifyStart(build, changes);
         } else {
@@ -110,7 +110,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
         }
     }
 
-    String getChanges(AbstractBuild r) {
+    String getChanges(AbstractBuild r, boolean includeCustomMessage) {
         if (!r.hasChangeSetComputed()) {
             logger.info("No change set computed...");
             return null;
@@ -138,7 +138,11 @@ public class ActiveNotifier implements FineGrainedNotifier {
         message.append(" (");
         message.append(files.size());
         message.append(" file(s) changed)");
-        return message.appendOpenLink().toString();
+        message.appendOpenLink();
+        if (includeCustomMessage) {
+            message.appendCustomMessage();
+        }
+        return message.toString();
     }
 
     String getCommitList(AbstractBuild r) {
@@ -296,7 +300,6 @@ public class ActiveNotifier implements FineGrainedNotifier {
         }
 
         public MessageBuilder appendCustomMessage() {
-            AbstractProject<?, ?> project = build.getProject();
             String customMessage = notifier.getCustomMessage();
             EnvVars envVars = new EnvVars();
             try {


### PR DESCRIPTION
In response to issue #94.
This change appends the custom message if changes are found when building. This is probably the simplest way to resolve the issue for now. However, I think the code could be cleaner, and so I'm going to work at providing a better implementation for the custom message as a whole. 