### PR TITLE
Set test connection message color correctly.

### DIFF
--- a/src/main/java/jenkins/plugins/slack/SlackNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/SlackNotifier.java
@@ -207,7 +207,7 @@ public class SlackNotifier extends Notifier {
             try {
                 SlackService testSlackService = getSlackService(teamDomain, authToken, room);
                 String message = "Slack/Jenkins plugin: you're all set on " + buildServerUrl;
-                boolean success = testSlackService.publish(message, "green");
+                boolean success = testSlackService.publish(message, "good");
                 return success ? FormValidation.ok("Success") : FormValidation.error("Failure");
             } catch (Exception e) {
                 return FormValidation.error("Client error : " + e.getMessage());
@@ -394,7 +394,7 @@ public class SlackNotifier extends Notifier {
                 try {
                     SlackService testSlackService = new StandardSlackService(teamDomain, authToken, room);
                     String message = "Slack/Jenkins plugin: you're all set.";
-                    boolean success = testSlackService.publish(message, "green");
+                    boolean success = testSlackService.publish(message, "good");
                     return success ? FormValidation.ok("Success") : FormValidation.error("Failure");
                 } catch (Exception e) {
                     return FormValidation.error("Client error : " + e.getMessage());


### PR DESCRIPTION
The doTestConnection methods currently set the message color to "green". From the slack api docs: "An optional value that can either be one of good, warning, danger, or any hex color code". This PR simply replaces "green" with "good" to achieve the desired outcome. 

Color set to "green":
![screen shot 2015-05-22 at 2 33 05 pm](https://cloud.githubusercontent.com/assets/6313470/7770507/826bcbde-008f-11e5-8a17-0b8819cb701d.png)

Color set to "good":
![screen shot 2015-05-22 at 2 33 59 pm](https://cloud.githubusercontent.com/assets/6313470/7770514/99b96a1c-008f-11e5-98ce-60a6150991b9.png)

