### PR TITLE
Allow simple markup formatting in custom messages

### DIFF
--- a/src/main/java/jenkins/plugins/slack/StandardSlackService.java
+++ b/src/main/java/jenkins/plugins/slack/StandardSlackService.java
@@ -56,6 +56,11 @@ public class StandardSlackService implements SlackService {
                 attachment.put("fallback", message);
                 attachment.put("color", color);
                 attachment.put("fields", fields);
+                JSONArray mrkdwn = new JSONArray();
+                mrkdwn.put("pretext");
+                mrkdwn.put("text");
+                mrkdwn.put("fields");
+                attachment.put("mrkdwn_in", mrkdwn);
                 JSONArray attachments = new JSONArray();
                 attachments.put(attachment);
 


### PR DESCRIPTION
To enable formatting on attachment fields, we have to set the `mrkdwn_in` array on each attachment to the list of fields to process. More details in the _Message Formatting_ section of: https://api.slack.com/docs/formatting
