### PR TITLE
[FIXED JENKINS-30559] Dropdown list to select commit info for notifications

### DIFF
--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -104,7 +104,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
                 || (result == Result.UNSTABLE && notifier.getNotifyUnstable())) {
             getSlack(r).publish(getBuildStatusMessage(r, notifier.includeTestSummary(),
                     notifier.includeCustomMessage()), getBuildColor(r));
-            if (notifier.getShowCommitList()) {
+            if (notifier.getCommitInfoChoice().showAnything()) {
                 getSlack(r).publish(getCommitList(r), getBuildColor(r));
             }
         }
@@ -168,8 +168,13 @@ public class ActiveNotifier implements FineGrainedNotifier {
         Set<String> commits = new HashSet<String>();
         for (Entry entry : entries) {
             StringBuffer commit = new StringBuffer();
-            commit.append(entry.getMsg());
-            commit.append(" [").append(entry.getAuthor().getDisplayName()).append("]");
+            CommitInfoChoice commitInfoChoice = notifier.getCommitInfoChoice();
+            if (commitInfoChoice.showTitle()) {
+                commit.append(entry.getMsg());
+            }
+            if (commitInfoChoice.showAuthor()) {
+                commit.append(" [").append(entry.getAuthor().getDisplayName()).append("]");
+            }
             commits.add(commit.toString());
         }
         MessageBuilder message = new MessageBuilder(notifier, r);

--- a/src/main/java/jenkins/plugins/slack/CommitInfoChoice.java
+++ b/src/main/java/jenkins/plugins/slack/CommitInfoChoice.java
@@ -1,0 +1,61 @@
+package jenkins.plugins.slack;
+
+public enum CommitInfoChoice {
+    NONE("nothing about commits") {
+        @Override
+        public boolean showAuthor() {
+            return false;
+        }
+        @Override
+        public boolean showTitle() {
+            return false;
+        }
+    },
+
+    AUTHORS("commit list with authors only") {
+        @Override
+        public boolean showAuthor() {
+            return true;
+        }
+        @Override
+        public boolean showTitle() {
+            return false;
+        }
+    },
+
+    AUTHORS_AND_TITLES("commit list with authors and titles") {
+        @Override
+        public boolean showAuthor() {
+            return true;
+        }
+        @Override
+        public boolean showTitle() {
+            return true;
+        }
+    };
+
+    private final String displayName;
+
+    private CommitInfoChoice(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public abstract boolean showAuthor();
+    public abstract boolean showTitle();
+    public boolean showAnything() {
+        return showAuthor() || showTitle();
+    }
+
+    public String getDisplayName() {
+        return this.displayName;
+    }
+
+    public static CommitInfoChoice forDisplayName(String displayName) {
+        for (CommitInfoChoice commitInfoChoice : values()) {
+            if (commitInfoChoice.getDisplayName().equals(displayName)) {
+                return commitInfoChoice;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/jenkins/plugins/slack/CommitInfoChoice.java
+++ b/src/main/java/jenkins/plugins/slack/CommitInfoChoice.java
@@ -1,47 +1,26 @@
 package jenkins.plugins.slack;
 
 public enum CommitInfoChoice {
-    NONE("nothing about commits") {
-        @Override
-        public boolean showAuthor() {
-            return false;
-        }
-        @Override
-        public boolean showTitle() {
-            return false;
-        }
-    },
-
-    AUTHORS("commit list with authors only") {
-        @Override
-        public boolean showAuthor() {
-            return true;
-        }
-        @Override
-        public boolean showTitle() {
-            return false;
-        }
-    },
-
-    AUTHORS_AND_TITLES("commit list with authors and titles") {
-        @Override
-        public boolean showAuthor() {
-            return true;
-        }
-        @Override
-        public boolean showTitle() {
-            return true;
-        }
-    };
+    NONE("nothing about commits",                             false, false),
+    AUTHORS("commit list with authors only",                  true,  false),
+    AUTHORS_AND_TITLES("commit list with authors and titles", true,  true);
 
     private final String displayName;
+    private boolean showAuthor;
+    private boolean showTitle;
 
-    private CommitInfoChoice(String displayName) {
+    private CommitInfoChoice(String displayName, boolean showAuthor, boolean showTitle) {
         this.displayName = displayName;
+        this.showAuthor = showAuthor;
+        this.showTitle = showTitle;
     }
 
-    public abstract boolean showAuthor();
-    public abstract boolean showTitle();
+    public boolean showAuthor() {
+        return this.showAuthor;
+    }
+    public boolean showTitle() {
+        return this.showTitle;
+    }
     public boolean showAnything() {
         return showAuthor() || showTitle();
     }

--- a/src/main/java/jenkins/plugins/slack/SlackNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/SlackNotifier.java
@@ -41,7 +41,7 @@ public class SlackNotifier extends Notifier {
     private boolean notifyBackToNormal;
     private boolean notifyRepeatedFailure;
     private boolean includeTestSummary;
-    private boolean showCommitList;
+    private CommitInfoChoice commitInfoChoice;
     private boolean includeCustomMessage;
     private String customMessage;
 
@@ -84,8 +84,8 @@ public class SlackNotifier extends Notifier {
         return notifySuccess;
     }
 
-    public boolean getShowCommitList() {
-        return showCommitList;
+    public CommitInfoChoice getCommitInfoChoice() {
+        return commitInfoChoice;
     }
 
     public boolean getNotifyAborted() {
@@ -128,7 +128,7 @@ public class SlackNotifier extends Notifier {
     public SlackNotifier(final String teamDomain, final String authToken, final String room, final String buildServerUrl,
                          final String sendAs, final boolean startNotification, final boolean notifyAborted, final boolean notifyFailure,
                          final boolean notifyNotBuilt, final boolean notifySuccess, final boolean notifyUnstable, final boolean notifyBackToNormal,
-                         final boolean notifyRepeatedFailure, final boolean includeTestSummary, final boolean showCommitList,
+                         final boolean notifyRepeatedFailure, final boolean includeTestSummary, CommitInfoChoice commitInfoChoice,
                          boolean includeCustomMessage, String customMessage) {
         super();
         this.teamDomain = teamDomain;
@@ -145,7 +145,7 @@ public class SlackNotifier extends Notifier {
         this.notifyBackToNormal = notifyBackToNormal;
         this.notifyRepeatedFailure = notifyRepeatedFailure;
         this.includeTestSummary = includeTestSummary;
-        this.showCommitList = showCommitList;
+        this.commitInfoChoice = commitInfoChoice;
         this.includeCustomMessage = includeCustomMessage;
         this.customMessage = customMessage;
     }
@@ -210,6 +210,8 @@ public class SlackNotifier extends Notifier {
         private String buildServerUrl;
         private String sendAs;
 
+        public static final CommitInfoChoice[] COMMIT_INFO_CHOICES = CommitInfoChoice.values();
+
         public DescriptorImpl() {
             load();
         }
@@ -258,12 +260,12 @@ public class SlackNotifier extends Notifier {
             boolean notifyBackToNormal = "true".equals(sr.getParameter("slackNotifyBackToNormal"));
             boolean notifyRepeatedFailure = "true".equals(sr.getParameter("slackNotifyRepeatedFailure"));
             boolean includeTestSummary = "true".equals(sr.getParameter("includeTestSummary"));
-            boolean showCommitList = "true".equals(sr.getParameter("slackShowCommitList"));
+            CommitInfoChoice commitInfoChoice = CommitInfoChoice.forDisplayName(sr.getParameter("slackCommitInfoChoice"));
             boolean includeCustomMessage = "on".equals(sr.getParameter("includeCustomMessage"));
             String customMessage = sr.getParameter("customMessage");
             return new SlackNotifier(teamDomain, token, room, buildServerUrl, sendAs, startNotification, notifyAborted,
                     notifyFailure, notifyNotBuilt, notifySuccess, notifyUnstable, notifyBackToNormal, notifyRepeatedFailure,
-                    includeTestSummary, showCommitList, includeCustomMessage, customMessage);
+                    includeTestSummary, commitInfoChoice, includeCustomMessage, customMessage);
         }
 
         @Override

--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
@@ -43,8 +43,12 @@
             </f:entry>
         </f:optionalBlock>
 
-        <f:entry title="Show Commit List with Titles and Authors">
-            <f:checkbox name="slackShowCommitList" value="true" checked="${instance.getShowCommitList()}"/>
+        <f:entry title="Notification message includes" description="What commit information to include into notification message">
+            <select class="setting-input" name="slackCommitInfoChoice">
+                <j:forEach var="i" items="${descriptor.COMMIT_INFO_CHOICES}">
+                    <f:option selected="${instance.getCommitInfoChoice()==i}">${i.getDisplayName()}</f:option>
+                </j:forEach>
+            </select>
         </f:entry>
 
         <f:entry title="Team Domain" help="${rootURL}/plugin/slack/help-projectConfig-slackTeamDomain.html">

--- a/src/test/java/jenkins/plugins/slack/SlackNotifierStub.java
+++ b/src/test/java/jenkins/plugins/slack/SlackNotifierStub.java
@@ -5,11 +5,11 @@ public class SlackNotifierStub extends SlackNotifier {
     public SlackNotifierStub(String teamDomain, String authToken, String room, String buildServerUrl,
                              String sendAs, boolean startNotification, boolean notifyAborted, boolean notifyFailure,
                              boolean notifyNotBuilt, boolean notifySuccess, boolean notifyUnstable, boolean notifyBackToNormal,
-                             boolean notifyRepeatedFailure, boolean includeTestSummary, boolean showCommitList,
+                             boolean notifyRepeatedFailure, boolean includeTestSummary, CommitInfoChoice commitInfoChoice,
                              boolean includeCustomMessage, String customMessage) {
         super(teamDomain, authToken, room, buildServerUrl, sendAs, startNotification, notifyAborted, notifyFailure,
                 notifyNotBuilt, notifySuccess, notifyUnstable, notifyBackToNormal, notifyRepeatedFailure,
-                includeTestSummary, showCommitList, includeCustomMessage, customMessage);
+                includeTestSummary, commitInfoChoice, includeCustomMessage, customMessage);
     }
 
     public static class DescriptorImplStub extends SlackNotifier.DescriptorImpl {


### PR DESCRIPTION
Convert existing checkbox "Show Commit List with Title and Authors"
into a dropdown list with the following options:
 - nothing about commits
 - commit list with authors only
 - commit list with authors and titles

This list can be easily extended with new options.