### PR TITLE
Fix #96 double start message when build is manually started

### DIFF
--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -60,6 +60,8 @@ public class ActiveNotifier implements FineGrainedNotifier {
                 MessageBuilder message = new MessageBuilder(notifier, build);
                 message.append(causeAction.getShortDescription());
                 notifyStart(build, message.appendOpenLink().toString());
+                // Cause was found, exit early to prevent double-message
+                return;
             }
         }
 


### PR DESCRIPTION
This isn't *technically* tested but I think the change is pretty obvious