### PR TITLE
Independent notify repeated failure/notify failure

### DIFF
--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -93,13 +93,16 @@ public class ActiveNotifier implements FineGrainedNotifier {
         } while (previousBuild != null && previousBuild.getResult() == Result.ABORTED);
         Result previousResult = (previousBuild != null) ? previousBuild.getResult() : Result.SUCCESS;
         if ((result == Result.ABORTED && notifier.getNotifyAborted())
-                || (result == Result.FAILURE
-                && (previousResult != Result.FAILURE || notifier.getNotifyRepeatedFailure())
-                && notifier.getNotifyFailure())
+                || (result == Result.FAILURE //notify only on single failed build
+                    && previousResult != Result.FAILURE
+                    && notifier.getNotifyFailure())
+                || (result == Result.FAILURE //notify only on repeated failures
+                    && previousResult == Result.FAILURE
+                    && notifier.getNotifyRepeatedFailure())
                 || (result == Result.NOT_BUILT && notifier.getNotifyNotBuilt())
                 || (result == Result.SUCCESS
-                && (previousResult == Result.FAILURE || previousResult == Result.UNSTABLE)
-                && notifier.getNotifyBackToNormal())
+                    && (previousResult == Result.FAILURE || previousResult == Result.UNSTABLE)
+                    && notifier.getNotifyBackToNormal())
                 || (result == Result.SUCCESS && notifier.getNotifySuccess())
                 || (result == Result.UNSTABLE && notifier.getNotifyUnstable())) {
             getSlack(r).publish(getBuildStatusMessage(r, notifier.includeTestSummary(),


### PR DESCRIPTION
fixes #136

Previously notify repeated failure would only work if notify failure option was checked.  This detaches the behavior so that either or could be checked.

If notify failure is enabled and notify repeated failure is disabled then Jenkins will only notify slack on the first failed build.

If notify failure is disabled and notify repeated failure is enabled then Jenkins will only notify slack on repeated failed builds but not the first failed build.

If both notify failure and notify repeated failure is enabled then Jenkins will notify slack on every failed build.