### PR TITLE
Avoid logging posting succeeded in some error cases.

### DIFF
--- a/src/main/java/jenkins/plugins/slack/StandardSlackService.java
+++ b/src/main/java/jenkins/plugins/slack/StandardSlackService.java
@@ -75,11 +75,13 @@ public class StandardSlackService implements SlackService {
                     logger.log(Level.WARNING, "Slack post may have failed. Response: " + response);
                     result = false;
                 }
+                else {
+                    logger.info("Posting succeeded");
+                }
             } catch (Exception e) {
                 logger.log(Level.WARNING, "Error posting to Slack", e);
                 result = false;
             } finally {
-                logger.info("Posting succeeded");
                 post.releaseConnection();
             }
         }


### PR DESCRIPTION
Logging the "Posting succeeded" message was previously in the "finally" block; it could be hit after an exception was thrown from e.g. HttpClient's executeMethod.  Now do it only when there's an OK response, and nothing prior has thrown.

(This has been compiled and packaged but not yet deployed locally.)