### PR TITLE
Adding configurable webhook endpoint for exposing jenkins commands with a Slack outgoing-webhook

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.4.4</version>
+        </dependency>
+        <dependency>
             <groupId>commons-httpclient</groupId>
             <artifactId>commons-httpclient</artifactId>
             <version>3.1</version>
@@ -53,6 +58,12 @@
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20131018</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/jenkins/plugins/slack/webhook/CommandRouter.java
+++ b/src/main/java/jenkins/plugins/slack/webhook/CommandRouter.java
@@ -1,0 +1,97 @@
+package jenkins.plugins.slack.webhook;
+
+
+import java.util.List;
+import java.util.ArrayList;
+
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+
+import jenkins.plugins.slack.webhook.exception.CommandRouterException;
+import jenkins.plugins.slack.webhook.exception.RouteNotFoundException;
+
+
+
+
+public class CommandRouter<T> {
+
+    public CommandRouter() { }
+
+    public List<Route<T>> routes = new ArrayList<Route<T>>();
+
+    public CommandRouter<T> addRoute(String regex,
+        String command,
+        String commandDescription,
+        RouterCommand<T> routerCommand) {
+
+        this.routes.add(new CommandRouter.Route<T>(regex,
+            command,
+            commandDescription,
+            routerCommand));
+
+        return this;
+    }
+
+    public List<Route<T>> getRoutes() {
+        return this.routes;
+    }
+
+    public T route(String command) throws CommandRouterException,
+        RouteNotFoundException {
+
+        T message = null;
+
+        for (Route<T> pa : routes) {
+
+            Matcher matcher = pa.regex.matcher(command);
+
+            boolean matches = matcher.matches();
+
+            if (matches) {
+    
+                String[] parametersArray = null;
+
+                if (matcher.groupCount() == 0) {
+                    parametersArray = new String[] { command };
+                } else {
+                    parametersArray = new String[matcher.groupCount()];
+
+                    for (int i = 1; i <= matcher.groupCount(); i++) {
+                        parametersArray[i-1] = matcher.group(i);
+                    }
+                }
+                
+                try {
+                    message = pa.routerCommand.execute(parametersArray);
+                } catch (Exception ex) {
+                    throw new CommandRouterException(ex.getMessage());
+                }
+
+                if (message == null)
+                    throw new RouteNotFoundException("No route found for given command", command);
+
+                return message;
+            }
+        }
+
+        return message;
+    }
+
+    public static class Route<T> {
+        public Pattern regex;
+        public String command;
+        public String commandDescription;
+        public RouterCommand<T> routerCommand;
+
+        public Route(String regex,
+            String command,
+            String commandDescription,
+            RouterCommand<T> routerCommand) {
+
+            this.regex = Pattern.compile(regex);
+            this.routerCommand = routerCommand;
+            this.command = command;
+            this.commandDescription = commandDescription;
+        }
+    }
+}

--- a/src/main/java/jenkins/plugins/slack/webhook/GetProjectLogCommand.java
+++ b/src/main/java/jenkins/plugins/slack/webhook/GetProjectLogCommand.java
@@ -1,0 +1,76 @@
+package jenkins.plugins.slack.webhook;
+
+
+import jenkins.model.Jenkins;
+
+import hudson.model.Build;
+import hudson.model.Result;
+import hudson.model.Project;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+
+import hudson.security.ACL;
+
+import java.io.IOException;
+
+import java.util.List;
+import java.util.ArrayList;
+
+import org.kohsuke.stapler.interceptor.RequirePOST;
+
+import jenkins.plugins.slack.webhook.model.SlackPostData;
+import jenkins.plugins.slack.webhook.model.SlackTextMessage;
+import jenkins.plugins.slack.webhook.model.SlackWebhookCause;
+
+import org.acegisecurity.context.SecurityContext;
+import org.acegisecurity.context.SecurityContextHolder;
+
+
+
+
+public class GetProjectLogCommand extends SlackRouterCommand implements RouterCommand<SlackTextMessage> {
+
+    public GetProjectLogCommand(SlackPostData data) { 
+        super(data);
+    }
+
+    @Override
+    public SlackTextMessage execute(String... args) {
+        String projectName = args[0];
+        String buildNumber = args[1];
+
+        SecurityContext ctx = ACL.impersonate(ACL.SYSTEM);
+
+        List<String> log = new ArrayList<String>();
+
+        try {
+            Project project =
+                Jenkins.getInstance().getItemByFullName(projectName, Project.class);
+
+            if (project == null)
+                return new SlackTextMessage("Could not find project ("+projectName+")\n");
+
+            AbstractBuild build =
+                project.getBuildByNumber(Integer.parseInt(buildNumber));
+
+            if (build == null)
+                return new SlackTextMessage("Could not find build #"+buildNumber+" for ("+projectName+")\n");
+
+            log = build.getLog(25);
+
+        } catch (IOException ex) {
+            return new SlackTextMessage("Error occured returning log: "+ex.getMessage());
+        } finally {
+            SecurityContextHolder.setContext(ctx);
+        }
+
+        String response = "*"+projectName+"* *#"+buildNumber+"*\n";
+        response += "```";
+        for (String line : log) {
+            response += line + "\n";
+        }
+        response += "```";
+
+        return new SlackTextMessage(response);
+    }
+}

--- a/src/main/java/jenkins/plugins/slack/webhook/GlobalConfig.java
+++ b/src/main/java/jenkins/plugins/slack/webhook/GlobalConfig.java
@@ -1,0 +1,67 @@
+package jenkins.plugins.slack.webhook;
+
+
+import hudson.Extension;
+
+import net.sf.json.JSONObject;
+
+import jenkins.model.GlobalConfiguration;
+
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+
+import hudson.util.FormValidation;
+
+import hudson.model.Descriptor.FormException;
+
+
+
+
+
+@Extension
+public class GlobalConfig extends GlobalConfiguration {
+
+    private String slackOutgoingWebhookToken;
+    private String slackOutgoingWebhookURL;
+
+    public GlobalConfig() { 
+        load(); 
+    }
+
+    public String getSlackOutgoingWebhookToken() {
+        return slackOutgoingWebhookToken;
+    }
+
+    public void setSlackOutgoingWebhookToken(String slackOutgoingWebhookToken) {
+        this.slackOutgoingWebhookToken = slackOutgoingWebhookToken;
+    }
+
+    public FormValidation doCheckSlackOutgoingWebhookToken(@QueryParameter String value) {
+        if (value == null || value.trim().isEmpty())
+            return FormValidation.warning("Please set a Slack outgoing webhook token");
+
+        return FormValidation.ok();
+    }
+
+    public String getSlackOutgoingWebhookURL() {
+        return slackOutgoingWebhookURL;
+    }
+
+    public void setSlackOutgoingWebhookURL(String slackOutgoingWebhookURL) {
+        this.slackOutgoingWebhookURL = slackOutgoingWebhookURL;
+    }
+
+    public FormValidation doCheckSlackOutgoingWebhookURL(@QueryParameter String value) {
+        if (value == null || value.trim().isEmpty())
+            return FormValidation.warning("Please set a url endpoint");
+
+        return FormValidation.ok();
+    }
+
+    @Override
+    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+        req.bindJSON(this, json);
+        save();
+        return true;
+    }
+}

--- a/src/main/java/jenkins/plugins/slack/webhook/ListProjectsCommand.java
+++ b/src/main/java/jenkins/plugins/slack/webhook/ListProjectsCommand.java
@@ -1,0 +1,85 @@
+package jenkins.plugins.slack.webhook;
+
+
+import jenkins.model.Jenkins;
+
+import hudson.model.Build;
+import hudson.model.Result;
+import hudson.model.Project;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+
+import hudson.security.ACL;
+
+import java.io.IOException;
+
+import java.util.List;
+import java.util.ArrayList;
+
+import org.kohsuke.stapler.interceptor.RequirePOST;
+
+import jenkins.plugins.slack.webhook.model.SlackPostData;
+import jenkins.plugins.slack.webhook.model.SlackTextMessage;
+import jenkins.plugins.slack.webhook.model.SlackWebhookCause;
+
+import org.acegisecurity.context.SecurityContext;
+import org.acegisecurity.context.SecurityContextHolder;
+
+
+
+
+public class ListProjectsCommand extends SlackRouterCommand implements RouterCommand<SlackTextMessage> {
+
+    public ListProjectsCommand(SlackPostData data) { 
+        super(data);
+    }
+
+    @Override
+    public SlackTextMessage execute(String... args) {
+
+        SecurityContext ctx = ACL.impersonate(ACL.SYSTEM);
+
+        String response = "*Projects:*\n";
+
+        List<AbstractProject> jobs =
+            Jenkins.getInstance().getAllItems(AbstractProject.class);
+
+        SecurityContextHolder.setContext(ctx);
+
+        for (AbstractProject job : jobs) {
+            if (job.isBuildable()) {
+                AbstractBuild lastBuild = job.getLastBuild();
+                String buildNumber = "TBD";
+                String status = "TBD";
+                if (lastBuild != null) {
+
+                    buildNumber = Integer.toString(lastBuild.getNumber());
+
+                    if (lastBuild.isBuilding()) {
+                        status = "BUILDING";
+                    }
+
+                    Result result = lastBuild.getResult();
+
+                    if (result != null) {
+                        status = result.toString();
+                    }
+                }
+
+                if (jobs.size() <= 10) {
+                    response += ">*"+job.getDisplayName() + "*\n>*Last Build:* #"+buildNumber+"\n>*Status:* "+status;
+                    response += "\n\n\n";
+                } else {
+                    response += ">*"+job.getDisplayName() + "* :: *Last Build:* #"+buildNumber+" :: *Status:* "+status;
+                    response += "\n\n";
+                }
+            }
+        }
+
+        if (jobs == null || jobs.size() == 0)
+            response += ">_No projects found_";
+
+        return new SlackTextMessage(response);
+    }
+}
+

--- a/src/main/java/jenkins/plugins/slack/webhook/RouterCommand.java
+++ b/src/main/java/jenkins/plugins/slack/webhook/RouterCommand.java
@@ -1,0 +1,8 @@
+package jenkins.plugins.slack.webhook;
+
+
+
+
+public interface RouterCommand<T> {
+    public T execute(String... args);
+}

--- a/src/main/java/jenkins/plugins/slack/webhook/ScheduleJobCommand.java
+++ b/src/main/java/jenkins/plugins/slack/webhook/ScheduleJobCommand.java
@@ -1,0 +1,61 @@
+package jenkins.plugins.slack.webhook;
+
+
+import jenkins.model.Jenkins;
+
+import hudson.model.Build;
+import hudson.model.Result;
+import hudson.model.Project;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+
+import hudson.security.ACL;
+
+import java.io.IOException;
+
+import java.util.List;
+import java.util.ArrayList;
+
+import org.kohsuke.stapler.interceptor.RequirePOST;
+
+import jenkins.plugins.slack.webhook.model.SlackPostData;
+import jenkins.plugins.slack.webhook.model.SlackTextMessage;
+import jenkins.plugins.slack.webhook.model.SlackWebhookCause;
+
+import org.acegisecurity.context.SecurityContext;
+import org.acegisecurity.context.SecurityContextHolder;
+
+
+
+
+public class ScheduleJobCommand extends SlackRouterCommand implements RouterCommand<SlackTextMessage> {
+
+    public ScheduleJobCommand(SlackPostData data) { 
+        super(data);
+    }
+
+    @Override
+    public SlackTextMessage execute(String... args) {
+
+        String projectName = args[0];
+        SecurityContext ctx = ACL.impersonate(ACL.SYSTEM);
+
+        String response = "";
+
+        Project project =
+            Jenkins.getInstance().getItemByFullName(projectName, Project.class);
+
+        try {
+            if (project == null)
+                return new SlackTextMessage("Could not find project ("+projectName+")\n");
+
+            if (project.scheduleBuild(new SlackWebhookCause(this.getData().getUser_name()))) {
+                return new SlackTextMessage("Build scheduled for project "+ projectName+"\n");
+            } else {
+                return new SlackTextMessage("Build not scheduled due to an issue with Jenkins");
+            }
+        } finally {
+            SecurityContextHolder.setContext(ctx);
+        }
+    }
+}

--- a/src/main/java/jenkins/plugins/slack/webhook/SlackRouterCommand.java
+++ b/src/main/java/jenkins/plugins/slack/webhook/SlackRouterCommand.java
@@ -1,0 +1,23 @@
+package jenkins.plugins.slack.webhook;
+
+
+import jenkins.plugins.slack.webhook.model.SlackPostData;
+
+
+
+
+public abstract class SlackRouterCommand {
+    private SlackPostData data;
+
+    public SlackRouterCommand(SlackPostData data) {
+        this.data = data;
+    }
+
+    public SlackPostData getData() {
+        return this.data;
+    }
+
+    public void setData(SlackPostData data) {
+        this.data = data;
+    }
+}

--- a/src/main/java/jenkins/plugins/slack/webhook/WebhookEndpoint.java
+++ b/src/main/java/jenkins/plugins/slack/webhook/WebhookEndpoint.java
@@ -1,0 +1,149 @@
+package jenkins.plugins.slack.webhook;
+
+
+import jenkins.model.Jenkins;
+import jenkins.model.GlobalConfiguration;
+
+import hudson.Extension;
+
+import hudson.model.UnprotectedRootAction;
+
+import javax.servlet.ServletException;
+
+import java.io.IOException;
+
+import java.util.List;
+import java.util.ArrayList;
+
+import java.util.logging.Logger;
+
+import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+
+import org.kohsuke.stapler.interceptor.RequirePOST;
+
+import jenkins.plugins.slack.webhook.model.JsonResponse;
+import jenkins.plugins.slack.webhook.model.SlackPostData;
+import jenkins.plugins.slack.webhook.model.SlackTextMessage;
+
+import jenkins.plugins.slack.webhook.exception.CommandRouterException;
+import jenkins.plugins.slack.webhook.exception.RouteNotFoundException;
+
+
+
+
+@Extension
+public class WebhookEndpoint implements UnprotectedRootAction {
+
+    private GlobalConfig globalConfig;
+
+    private static final Logger LOGGER =
+        Logger.getLogger(WebhookEndpoint.class.getName());
+
+    public WebhookEndpoint() {
+        globalConfig = GlobalConfiguration.all().get(GlobalConfig.class);
+    }
+
+    @Override
+    public String getUrlName() {
+        String url = globalConfig.getSlackOutgoingWebhookURL();
+        if (url == null || url.equals(""))
+            return null;
+
+        return "/"+url;
+    }
+
+    @RequirePOST
+    public HttpResponse doIndex(StaplerRequest req) throws IOException,
+        ServletException {
+
+        if (globalConfig.getSlackOutgoingWebhookToken() == null ||
+            globalConfig.getSlackOutgoingWebhookToken().equals("")) {
+            return new JsonResponse(new SlackTextMessage("Slack token not set"),
+                StaplerResponse.SC_OK); 
+        }
+
+        SlackPostData data = new SlackPostData();
+        req.bindParameters(data);
+
+        if (!globalConfig.getSlackOutgoingWebhookToken().equals(data.getToken()))
+            return new JsonResponse(new SlackTextMessage("Invalid Slack token"),
+                StaplerResponse.SC_OK); 
+    
+        String commandText = data.getText();
+        if (commandText == null || commandText.isEmpty())
+            return new JsonResponse(new SlackTextMessage("Invalid command, text field required"),
+                StaplerResponse.SC_OK);
+
+        String triggerWord = data.getTrigger_word();
+        if (triggerWord == null || triggerWord.isEmpty())
+            return new JsonResponse(new SlackTextMessage("Invalid command, trigger_word field required"),
+                StaplerResponse.SC_OK);
+
+        if (!commandText.startsWith(triggerWord))
+            return new JsonResponse(new SlackTextMessage("Invalid command, invalid trigger_word"),
+                StaplerResponse.SC_OK);
+
+        commandText = commandText.trim().replaceFirst(triggerWord, "").trim();
+
+        CommandRouter<SlackTextMessage> router =
+            new CommandRouter<SlackTextMessage>();
+
+        try {
+            router.addRoute("^list projects",
+                triggerWord+" list projects",
+                "Return a list of buildable projects",
+                new ListProjectsCommand(data))
+            .addRoute("^run ([\\p{L}\\p{N}\\p{ASCII}\\W]+)",
+                triggerWord+" run <project_name>",
+                "Schedule a run for <project_name>",
+                new ScheduleJobCommand(data))
+            .addRoute("^get ([\\p{L}\\p{N}\\p{ASCII}\\W]+) #([0-9]+) log",
+                triggerWord+" get <project-name> #<build_number> log",
+                "Return a truncated log for build #<build_number> of <project_name>",
+                new GetProjectLogCommand(data));
+
+            SlackTextMessage msg = router.route(commandText);
+
+            return new JsonResponse(msg, StaplerResponse.SC_OK);
+            
+        } catch (RouteNotFoundException ex) {
+
+            LOGGER.warning(ex.getMessage());
+
+            String command = ex.getRouteCommand();
+
+            String response = "*Help:*\n";
+            if (command.split("\\s+").length > 1)
+                response += "`"+command+"` _is an unknown command, try one of the following:_\n\n";
+            else
+                response += "\n";
+
+            for (CommandRouter.Route route : router.getRoutes()) {
+                response += "`"+route.command+"`\n```"+route.commandDescription+"```";
+                response += "\n\n";
+            }
+
+            return new JsonResponse(new SlackTextMessage(response), StaplerResponse.SC_OK);
+
+        } catch (CommandRouterException ex) {
+            LOGGER.warning(ex.getMessage());
+            return new JsonResponse(new SlackTextMessage(ex.getMessage()), StaplerResponse.SC_OK);
+
+        } catch (Exception ex) {
+            LOGGER.warning(ex.getMessage());
+            return new JsonResponse(new SlackTextMessage("An error occured: "+ ex.getMessage()), StaplerResponse.SC_OK);
+        }
+    }
+
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return null;
+    }
+}

--- a/src/main/java/jenkins/plugins/slack/webhook/exception/CommandRouterException.java
+++ b/src/main/java/jenkins/plugins/slack/webhook/exception/CommandRouterException.java
@@ -1,0 +1,11 @@
+package jenkins.plugins.slack.webhook.exception;
+
+
+
+
+public class CommandRouterException extends Exception {
+
+    public CommandRouterException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/jenkins/plugins/slack/webhook/exception/RouteNotFoundException.java
+++ b/src/main/java/jenkins/plugins/slack/webhook/exception/RouteNotFoundException.java
@@ -1,0 +1,17 @@
+package jenkins.plugins.slack.webhook.exception;
+
+
+
+
+public class RouteNotFoundException extends CommandRouterException {
+    private String routeCommand;
+
+    public RouteNotFoundException(String message, String routeCommand) {
+        super(message);
+        this.routeCommand = routeCommand;
+    }
+
+    public String getRouteCommand() {
+        return routeCommand;
+    }
+}

--- a/src/main/java/jenkins/plugins/slack/webhook/model/JsonResponse.java
+++ b/src/main/java/jenkins/plugins/slack/webhook/model/JsonResponse.java
@@ -1,0 +1,46 @@
+package jenkins.plugins.slack.webhook.model;
+
+
+import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+
+import java.io.IOException;
+
+import net.sf.json.JSONObject;
+
+import javax.servlet.ServletException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+
+
+
+public class JsonResponse implements HttpResponse {
+    private int status;
+
+    private String json;
+
+    public JsonResponse(Object obj, int status) {
+        this.json = null;
+        try {
+            this.json = new ObjectMapper().writeValueAsString(obj);
+        } catch (JsonProcessingException ex) {
+            this.json = new JSONObject().put("text", ex.getMessage()).toString();
+        } 
+        this.status = status;
+    }
+
+    @Override
+    public void generateResponse(StaplerRequest req,
+        StaplerResponse rsp,
+        Object o) throws IOException, ServletException {
+
+        rsp.setStatus(status);
+        rsp.setContentType("application/json;charset=UTF-8");
+        rsp.getWriter().println(json);
+    }
+
+}

--- a/src/main/java/jenkins/plugins/slack/webhook/model/SlackPostData.java
+++ b/src/main/java/jenkins/plugins/slack/webhook/model/SlackPostData.java
@@ -1,0 +1,102 @@
+package jenkins.plugins.slack.webhook.model;
+
+
+
+
+public class SlackPostData {
+    private String text;
+    private String token;
+    private String team_id;
+    private String team_domain;
+    private String channel_id;
+    private String channel_name;
+    private String timestamp;
+    private String user_id;
+    private String user_name;
+    private String trigger_word;
+
+    public SlackPostData() {
+
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public String getText() {
+        return this.text;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public String getToken() {
+        return this.token;
+    }
+
+    public void setTeam_id(String team_id) {
+        this.team_id = team_id;
+    }
+
+    public String getTeam_id() {
+        return this.team_id;
+    }
+
+    public void setTeam_domain(String team_domain) {
+        this.team_domain = team_domain;
+    }
+
+    public String getTeam_domain() {
+        return this.team_domain;
+    }
+
+    public void setChannel_id(String channel_id) {
+        this.channel_id = channel_id;
+    }
+
+    public String getChannel_id() {
+        return this.channel_id;
+    }
+
+    public void setChannel_name(String channel_name) {
+        this.channel_name = channel_name;
+    }
+
+    public String getChannel_name() {
+        return this.channel_name;
+    }
+
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getTimestamp() {
+        return this.timestamp;
+    }
+
+    public void setUser_id(String user_id) {
+        this.user_id = user_id;
+    }
+
+    public String getUser_id() {
+        return this.user_id;
+    }
+
+    public void setUser_name(String user_name) {
+        this.user_name = user_name;
+    }
+
+    public String getUser_name() {
+        return this.user_name;
+    }
+
+    public void setTrigger_word(String trigger_word) {
+        this.trigger_word = trigger_word;
+    }
+
+    public String getTrigger_word() {
+        return this.trigger_word;
+    }
+}
+

--- a/src/main/java/jenkins/plugins/slack/webhook/model/SlackTextMessage.java
+++ b/src/main/java/jenkins/plugins/slack/webhook/model/SlackTextMessage.java
@@ -1,0 +1,22 @@
+package jenkins.plugins.slack.webhook.model;
+
+
+
+
+public class SlackTextMessage {
+    private String text;
+        
+    public SlackTextMessage() { }
+
+    public SlackTextMessage(String text) {
+        this.text = text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public String getText() {
+        return this.text;
+    }
+}

--- a/src/main/java/jenkins/plugins/slack/webhook/model/SlackWebhookCause.java
+++ b/src/main/java/jenkins/plugins/slack/webhook/model/SlackWebhookCause.java
@@ -1,0 +1,19 @@
+package jenkins.plugins.slack.webhook.model;
+
+import hudson.model.Cause;
+
+
+
+
+public class SlackWebhookCause extends Cause {
+    private String username;
+
+    public SlackWebhookCause(String username) {
+        this.username = username;
+    }
+
+    @Override
+    public String getShortDescription() {
+        return "Build started by Slack user @"+username+ " via SlackWebhookPlugin";
+    }
+}

--- a/src/main/resources/jenkins/plugins/slack/webhook/GlobalConfig/config.groovy
+++ b/src/main/resources/jenkins/plugins/slack/webhook/GlobalConfig/config.groovy
@@ -1,0 +1,12 @@
+package jenkins.plugins.slack.webhook.GlobalConfig;
+
+f = namespace('/lib/form')
+
+f.section(title: _('Slack Webhook Settings')) {
+    f.entry(field: 'slackOutgoingWebhookToken', title: _('Outgoing Webhook Token')) {
+        f.textbox()
+    }
+    f.entry(field: 'slackOutgoingWebhookURL', title: _('Outgoing Webhook URL Endpoint')) {
+        f.textbox()
+    }
+}

--- a/src/main/resources/jenkins/plugins/slack/webhook/GlobalConfig/help-slackOutgoingWebhookToken.html
+++ b/src/main/resources/jenkins/plugins/slack/webhook/GlobalConfig/help-slackOutgoingWebhookToken.html
@@ -1,0 +1,5 @@
+<div>
+This token is used to verify requests between Slack and Jenkins.
+<br />
+You can copy this token from the settings page for your outgoing webhook within Slack.
+</div>

--- a/src/main/resources/jenkins/plugins/slack/webhook/GlobalConfig/help-slackOutgoingWebhookURL.html
+++ b/src/main/resources/jenkins/plugins/slack/webhook/GlobalConfig/help-slackOutgoingWebhookURL.html
@@ -1,0 +1,15 @@
+<div>
+<b>Leaving this field blank will disable webhook functionality</b>.
+<br />
+<br />
+This is the webhook endpoint to send requests to, e.g. <i>webhook</i>, <i>slackwebhook</i>.
+<br />
+<br />
+The webhook endpoint is mapped to the root address of your Jenkins instance and needs to be publicly accessible.
+<br />
+<br />
+Example:<br /><br />If your Jenkins instance is <i>http://myjenkins.example.com</i> and your webhook endpoint is <i>slackwebhook</i>, you would set your Slack outgoing webhook url to:<br /><br />http://myjenkins.example.com/slackwebhook/.
+<br />
+<br />
+Note that the trailing slash is required.
+</div>

--- a/src/test/java/jenkins/plugins/slack/webhook/WebhookEndpointTest.java
+++ b/src/test/java/jenkins/plugins/slack/webhook/WebhookEndpointTest.java
@@ -1,0 +1,203 @@
+package jenkins.plugins.slack.webhook;
+
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.Before;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.containsString;
+
+import static org.junit.Assert.assertThat;
+
+import com.gargoylesoftware.htmlunit.WebResponse;
+import com.gargoylesoftware.htmlunit.WebRequestSettings;
+import static com.gargoylesoftware.htmlunit.HttpMethod.POST;
+
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlInput;
+
+import hudson.tasks.Shell;
+
+import org.jvnet.hudson.test.JenkinsRule;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+
+import org.apache.commons.httpclient.NameValuePair;
+
+import java.util.List;
+import java.util.ArrayList;
+
+import hudson.model.FreeStyleProject;
+import jenkins.model.GlobalConfiguration;
+
+import jenkins.plugins.slack.webhook.model.SlackTextMessage;
+
+
+
+
+public class WebhookEndpointTest {
+
+    private JenkinsRule.WebClient client;
+
+    private final String URL = "webook";
+    private final String ENDPOINT = URL+"/";
+    private final String LONG_PROJECT_NAME = "¶12345678  90怒qwertyuioplkjhgfdsazxcvbnm~()-_=+7{},.\"'    5";
+
+    private List<NameValuePair> data;
+
+    @Rule
+    public final JenkinsRule jenkinsRule = new JenkinsRule();
+
+    
+    @Before
+    public void setUp() throws Exception {
+        client = jenkinsRule.createWebClient();
+        data = new ArrayList<NameValuePair>();
+        data.add(new NameValuePair("token", "GOOD_TOKEN"));
+        data.add(new NameValuePair("trigger_word", "jenkins")); 
+    }
+
+    @Test
+    public void testUnconfiguredSlackURL() throws Exception {
+        WebResponse response = makeRequest(null);
+        assertThat(response.getStatusCode(), is(HTTP_NOT_FOUND));
+    }
+
+    @Test
+    public void testUnconfiguredSlackToken() throws Exception {
+        HtmlForm form = jenkinsRule.createWebClient().goTo("configure").getFormByName("config");
+        form.getInputByName("_.slackOutgoingWebhookURL").setValueAttribute(URL);
+        jenkinsRule.submit(form);
+
+        WebResponse response = makeRequest(null);
+
+        assertThat(response.getStatusCode(), is(HTTP_OK));
+        assertThat(getSlackMessage(response).getText(), is("Slack token not set"));
+    }
+
+    @Test
+    public void testNoTextPostData() throws Exception {
+        setConfigSettings();
+        List<NameValuePair> goodToken = new ArrayList<NameValuePair>();
+        goodToken.add(new NameValuePair("token", "GOOD_TOKEN"));
+
+        WebResponse response = makeRequest(goodToken);
+        assertThat(getSlackMessage(response).getText(), is("Invalid command, text field required"));
+    } 
+
+    @Test
+    public void testNoTriggerWordPostData() throws Exception {
+        setConfigSettings();
+        List<NameValuePair> goodToken = new ArrayList<NameValuePair>();
+        goodToken.add(new NameValuePair("token", "GOOD_TOKEN"));
+        goodToken.add(new NameValuePair("text", "jenkins"));
+
+        WebResponse response = makeRequest(goodToken);
+        assertThat(getSlackMessage(response).getText(), is("Invalid command, trigger_word field required"));
+    }
+
+    @Test
+    public void testInvalidConfiguredSlackToken() throws Exception {
+        GlobalConfig config = GlobalConfiguration.all().get(GlobalConfig.class);        
+        assertThat(config.getSlackOutgoingWebhookToken(), is(nullValue()));
+
+        setConfigSettings();
+
+        List<NameValuePair> badData = new ArrayList<NameValuePair>();
+        badData.add(new NameValuePair("token", "BAD_TOKEN"));
+
+        WebResponse response = makeRequest(badData);
+        
+        assertThat(getSlackMessage(response).getText(), is("Invalid Slack token"));
+    }
+
+    @Test
+    public void testInvalidTriggerWord() throws Exception {
+        setConfigSettings();
+        data.add(new NameValuePair("text", "jenkinns list projects"));
+        WebResponse response = makeRequest(data);
+        assertThat(getSlackMessage(response).getText(), is("Invalid command, invalid trigger_word"));
+    }
+
+    @Test
+    public void testListProjects() throws Exception {
+        setConfigSettings(); 
+        data.add(new NameValuePair("text", "jenkins list projects")); 
+        WebResponse response = makeRequest(data);
+        assertThat(getSlackMessage(response).getText(), is("*Projects:*\n>_No projects found_"));
+
+        FreeStyleProject project = jenkinsRule.createFreeStyleProject(LONG_PROJECT_NAME);
+        response = makeRequest(data);
+        assertThat(getSlackMessage(response).getText(), is("*Projects:*\n>*"+LONG_PROJECT_NAME+"*\n>*Last Build:* #TBD\n>*Status:* TBD\n\n\n"));
+
+        project.scheduleBuild2(0).get();
+        response = makeRequest(data);
+        assertThat(getSlackMessage(response).getText(), is("*Projects:*\n>*"+LONG_PROJECT_NAME+"*\n>*Last Build:* #1\n>*Status:* SUCCESS\n\n\n"));
+    }
+
+    @Test
+    public void testRunNonExistantProject() throws Exception {
+        setConfigSettings();
+        data.add(new NameValuePair("text", "jenkins run project-1"));
+        WebResponse response = makeRequest(data);
+        assertThat(getSlackMessage(response).getText(), is("Could not find project (project-1)\n"));
+    }
+
+    @Test
+    public void testRunProject() throws Exception {
+        setConfigSettings();
+        FreeStyleProject project = jenkinsRule.createFreeStyleProject(LONG_PROJECT_NAME);
+        data.add(new NameValuePair("text", "jenkins run "+LONG_PROJECT_NAME));
+        WebResponse response = makeRequest(data);
+        assertThat(getSlackMessage(response).getText(), is("Build scheduled for project "+LONG_PROJECT_NAME+"\n"));
+    }
+
+    @Test
+    public void testGetProjectBuildLogWithNonExistantProject() throws Exception {
+        setConfigSettings();
+        data.add(new NameValuePair("text", "jenkins get project_1 #1 log"));
+        WebResponse response = makeRequest(data);
+        assertThat(getSlackMessage(response).getText(), is("Could not find project (project_1)\n"));
+    }
+
+    @Test
+    public void testGetProjectBuildLog() throws Exception {
+        setConfigSettings();
+        FreeStyleProject project = jenkinsRule.createFreeStyleProject(LONG_PROJECT_NAME);
+        project.scheduleBuild2(0).get();
+        data.add(new NameValuePair("text", "jenkins get "+LONG_PROJECT_NAME+" #1 log"));
+        WebResponse response = makeRequest(data);
+        assertThat(getSlackMessage(response).getText(), containsString("Building in workspace"));
+    }
+
+    private void setConfigSettings() throws Exception {
+        HtmlForm form = jenkinsRule.createWebClient().goTo("configure").getFormByName("config");
+        form.getInputByName("_.slackOutgoingWebhookURL").setValueAttribute(URL);
+        form.getInputByName("_.slackOutgoingWebhookToken").setValueAttribute("GOOD_TOKEN");
+        jenkinsRule.submit(form);
+    }
+
+    private SlackTextMessage getSlackMessage(WebResponse response) throws Exception { 
+        return new ObjectMapper().readValue(response.getContentAsString(),
+            SlackTextMessage.class);
+    }
+
+    private WebResponse makeRequest(List<NameValuePair> postData) throws Exception {
+        WebRequestSettings request =
+            new WebRequestSettings(client.createCrumbedUrl(ENDPOINT), POST);
+
+        if (postData != null)
+            request.setRequestParameters(postData);
+
+        request.setCharset("utf-8");
+
+        return client.loadWebResponse(request);
+    } 
+}


### PR DESCRIPTION
I've added an endpoint extension (/webhook/) to allow Slack outgoing-webhook functionality.

There is a new Slack Webhook Settings configuration option to add an outgoing-webhook token. 

I have placed everything in a new jenkins.plugins.slack.webhook package.