### PR TITLE
only send "Back to normal" if "Notify Back To Normal" is enabled

### DIFF
--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -249,7 +249,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
             return this;
         }
 
-        static String getStatusMessage(AbstractBuild r) {
+        private String getStatusMessage(AbstractBuild r) {
             if (r.isBuilding()) {
                 return STARTING_STATUS_MESSAGE;
             }
@@ -286,7 +286,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
              */
             if (result == Result.SUCCESS
                     && (previousResult == Result.FAILURE || previousResult == Result.UNSTABLE) 
-                    && buildHasSucceededBefore) {
+                    && buildHasSucceededBefore && notifier.getNotifyBackToNormal()) {
                 return BACK_TO_NORMAL_STATUS_MESSAGE;
             }
             if (result == Result.FAILURE && previousResult == Result.FAILURE) {


### PR DESCRIPTION
send a "Success" even if the previous build failed, if only "Notify
Success" is enabled but "Notify Back To Normal" is disabled.

I need this because I have a job to build pull requests. Then a "Back to normal" is weird because the successful build can be from another PR than the previous broken build. The failing PR is still failing.
