### PR TITLE
Subdomain instead of Domain

### DIFF
--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
@@ -51,7 +51,7 @@
             </select>
         </f:entry>
 
-        <f:entry title="Team Domain" help="${rootURL}/plugin/slack/help-projectConfig-slackTeamDomain.html">
+        <f:entry title="Team Subdomain" help="${rootURL}/plugin/slack/help-projectConfig-slackTeamDomain.html">
             <f:textbox name="slackTeamDomain" value="${instance.getTeamDomain()}"/>
         </f:entry>
 

--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/global.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/global.jelly
@@ -12,7 +12,7 @@
     so it should be straightforward to find them.
   -->
 <f:section title="Global Slack Notifier Settings" name="slack">
-    <f:entry title="Team Domain" help="${rootURL}/plugin/slack/help-globalConfig-slackTeamDomain.html">
+    <f:entry title="Team Subdomain" help="${rootURL}/plugin/slack/help-globalConfig-slackTeamDomain.html">
         <f:textbox field="teamDomain" name="slackTeamDomain" value="${descriptor.getTeamDomain()}" />
     </f:entry>
     <f:entry title="Integration Token" help="${rootURL}/plugin/slack/help-globalConfig-slackToken.html">


### PR DESCRIPTION
I think "Subdomain" is more clear. I first added the whole domain with ".slack.com"