### PR TITLE
Set webhook endpoint to random uuid based string if not set

### DIFF
--- a/src/main/java/jenkins/plugins/slack/webhook/WebhookEndpoint.java
+++ b/src/main/java/jenkins/plugins/slack/webhook/WebhookEndpoint.java
@@ -13,6 +13,7 @@ import javax.servlet.ServletException;
 import java.io.IOException;
 
 import java.util.List;
+import java.util.UUID;
 import java.util.ArrayList;
 
 import java.util.logging.Logger;
@@ -49,7 +50,7 @@ public class WebhookEndpoint implements UnprotectedRootAction {
     public String getUrlName() {
         String url = globalConfig.getSlackOutgoingWebhookURL();
         if (url == null || url.equals(""))
-            return null;
+            return UUID.randomUUID().toString().replaceAll("-", "");
 
         return "/"+url;
     }

--- a/src/test/java/jenkins/plugins/slack/webhook/WebhookEndpointTest.java
+++ b/src/test/java/jenkins/plugins/slack/webhook/WebhookEndpointTest.java
@@ -8,6 +8,7 @@ import org.junit.Before;
 import static org.junit.Assert.assertEquals;
 
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.containsString;
 
@@ -39,6 +40,8 @@ import jenkins.model.GlobalConfiguration;
 
 import jenkins.plugins.slack.webhook.model.SlackTextMessage;
 
+import jenkins.plugins.slack.webhook.WebhookEndpoint;
+
 
 
 
@@ -62,6 +65,14 @@ public class WebhookEndpointTest {
         data = new ArrayList<NameValuePair>();
         data.add(new NameValuePair("token", "GOOD_TOKEN"));
         data.add(new NameValuePair("trigger_word", "jenkins")); 
+    }
+
+    @Test
+    public void testNotNullOutgoingWebhookUrl() throws Exception {
+        WebhookEndpoint endpoint = new WebhookEndpoint();
+        String url = endpoint.getUrlName();
+        assertThat(url, is(not(nullValue())));
+        assertThat(url.isEmpty(), is(false));
     }
 
     @Test


### PR DESCRIPTION
Instead of returning null, which breaks certain Jenkins versions set the webhook endpoint to a random string.