### PR TITLE
Fix #62 by excluding empty affected files collection

### DIFF
--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -16,6 +16,7 @@ import hudson.scm.ChangeLogSet.Entry;
 import hudson.tasks.test.AbstractTestResultAction;
 import hudson.triggers.SCMTrigger;
 import hudson.util.LogTaskListener;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 
 import java.io.IOException;
@@ -128,7 +129,9 @@ public class ActiveNotifier implements FineGrainedNotifier {
             Entry entry = (Entry) o;
             logger.info("Entry " + o);
             entries.add(entry);
-            files.addAll(entry.getAffectedFiles());
+            if (CollectionUtils.isNotEmpty(entry.getAffectedFiles())) {
+                files.addAll(entry.getAffectedFiles());
+            }
         }
         if (entries.isEmpty()) {
             logger.info("Empty change...");


### PR DESCRIPTION
Jenkins Repo plugin adds an "empty" change log when there is a
new project added or removed, e.g.:

path: local/path
serverPath: server/path
revision: null
authorName: null
authorEmail: null
authorDate: null
committerName: null
committerEmail: null
committerDate: null
commitText: This project was added from the manifest.
modifiedFiles: null

When Slack plugin tries to add the "null" affected files, it gets a
NullPointerException error.

Fix the error by not adding any empty affected files collection.
