### PR TITLE
add baseUrl parameter to support slack-compatible integrations

### DIFF
--- a/src/main/java/jenkins/plugins/slack/StandardSlackService.java
+++ b/src/main/java/jenkins/plugins/slack/StandardSlackService.java
@@ -44,7 +44,7 @@ public class StandardSlackService implements SlackService {
         for (String roomId : roomIds) {
 
             String url = "https://" + teamDomain + "." + host + "/services/hooks/jenkins-ci?token=" + token;
-            if (StringUtils.isEmpty(baseUrl)) {
+            if (!StringUtils.isEmpty(baseUrl)) {
                 url = baseUrl + token;
             }
 

--- a/src/main/java/jenkins/plugins/slack/StandardSlackService.java
+++ b/src/main/java/jenkins/plugins/slack/StandardSlackService.java
@@ -1,9 +1,11 @@
 package jenkins.plugins.slack;
 
+import com.ctc.wstx.util.StringUtil;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.methods.PostMethod;
 
+import org.apache.commons.lang.StringUtils;
 import org.json.JSONObject;
 import org.json.JSONArray;
 
@@ -42,8 +44,9 @@ public class StandardSlackService implements SlackService {
         for (String roomId : roomIds) {
 
             String url = "https://" + teamDomain + "." + host + "/services/hooks/jenkins-ci?token=" + token;
-            if(baseUrl.length() > 0)
+            if (StringUtils.isEmpty(baseUrl)) {
                 url = baseUrl + token;
+            }
 
             logger.info("Posting: to " + roomId + " on " + teamDomain + " using " + url +": " + message + " " + color);
             HttpClient client = getHttpClient();

--- a/src/main/java/jenkins/plugins/slack/StandardSlackService.java
+++ b/src/main/java/jenkins/plugins/slack/StandardSlackService.java
@@ -20,12 +20,14 @@ public class StandardSlackService implements SlackService {
     private static final Logger logger = Logger.getLogger(StandardSlackService.class.getName());
 
     private String host = "slack.com";
+    private String baseUrl;
     private String teamDomain;
     private String token;
     private String[] roomIds;
 
-    public StandardSlackService(String teamDomain, String token, String roomId) {
+    public StandardSlackService(String baseUrl, String teamDomain, String token, String roomId) {
         super();
+        this.baseUrl = baseUrl;
         this.teamDomain = teamDomain;
         this.token = token;
         this.roomIds = roomId.split("[,; ]+");
@@ -38,7 +40,11 @@ public class StandardSlackService implements SlackService {
     public boolean publish(String message, String color) {
         boolean result = true;
         for (String roomId : roomIds) {
+
             String url = "https://" + teamDomain + "." + host + "/services/hooks/jenkins-ci?token=" + token;
+            if(baseUrl.length() > 0)
+                url = baseUrl + token;
+
             logger.info("Posting: to " + roomId + " on " + teamDomain + " using " + url +": " + message + " " + color);
             HttpClient client = getHttpClient();
             PostMethod post = new PostMethod(url);

--- a/src/main/java/jenkins/plugins/slack/workflow/SlackSendStep.java
+++ b/src/main/java/jenkins/plugins/slack/workflow/SlackSendStep.java
@@ -28,6 +28,7 @@ public class SlackSendStep extends AbstractStepImpl {
     private String color;
     private String token;
     private String channel;
+    private String baseUrl;
     private String teamDomain;
     private boolean failOnError;
 
@@ -62,6 +63,15 @@ public class SlackSendStep extends AbstractStepImpl {
     @DataBoundSetter
     public void setChannel(String channel) {
         this.channel = Util.fixEmpty(channel);
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    @DataBoundSetter
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl= Util.fixEmpty(baseUrl);
     }
 
     public String getTeamDomain() {
@@ -128,15 +138,16 @@ public class SlackSendStep extends AbstractStepImpl {
                 return null;
             }
             SlackNotifier.DescriptorImpl slackDesc = jenkins.getDescriptorByType(SlackNotifier.DescriptorImpl.class);
+            String baseUrl = step.baseUrl != null ? step.baseUrl : slackDesc.getBaseUrl();
             String team = step.teamDomain != null ? step.teamDomain : slackDesc.getTeamDomain();
             String token = step.token != null ? step.token : slackDesc.getToken();
             String channel = step.channel != null ? step.channel : slackDesc.getRoom();
             String color = step.color != null ? step.color : "";
 
             //placing in console log to simplify testing of retrieving values from global config or from step field; also used for tests
-            listener.getLogger().println(Messages.SlackSendStepConfig(step.teamDomain == null, step.token == null, step.channel == null, step.color == null));
+            listener.getLogger().println(Messages.SlackSendStepConfig(step.baseUrl == null, step.teamDomain == null, step.token == null, step.channel == null, step.color == null));
 
-            SlackService slackService = getSlackService(team, token, channel);
+            SlackService slackService = getSlackService(baseUrl, team, token, channel);
             boolean publishSuccess = slackService.publish(step.message, color);
             if (!publishSuccess && step.failOnError) {
                 throw new AbortException(Messages.NotificationFailed());
@@ -147,8 +158,8 @@ public class SlackSendStep extends AbstractStepImpl {
         }
 
         //streamline unit testing
-        SlackService getSlackService(String team, String token, String channel) {
-            return new StandardSlackService(team, token, channel);
+        SlackService getSlackService(String baseUrl, String team, String token, String channel) {
+            return new StandardSlackService(baseUrl, team, token, channel);
         }
 
     }

--- a/src/main/resources/jenkins/plugins/slack/Messages.properties
+++ b/src/main/resources/jenkins/plugins/slack/Messages.properties
@@ -4,4 +4,4 @@ SlackSendStepDisplayName=Send Slack Message
 # Messages to display in the build logs
 NotificationFailed=Slack notification failed. See Jenkins logs for details.
 NotificationFailedWithException=Slack notification failed with exception: {0}
-SlackSendStepConfig=Slack Send Pipeline step configured values from global config - teamDomain: {0}, token: {1}, channel: {2}, color: {3}
+SlackSendStepConfig=Slack Send Pipeline step configured values from global config - baseUrl: {0}, teamDomain: {1}, token: {2}, channel: {3}, color: {4}

--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
@@ -50,7 +50,9 @@
                 </j:forEach>
             </select>
         </f:entry>
-
+        <f:entry title="Base URL" help="${rootURL}/plugin/slack/help-projectConfig-slackTeamDomain.html">
+            <f:textbox name="slackBaseUrl" value="${instance.getBaseUrl()}"/>
+        </f:entry>
         <f:entry title="Team Subdomain" help="${rootURL}/plugin/slack/help-projectConfig-slackTeamDomain.html">
             <f:textbox name="slackTeamDomain" value="${instance.getTeamDomain()}"/>
         </f:entry>
@@ -64,6 +66,6 @@
         </f:entry>
         <f:validateButton
                 title="${%Test Connection}" progress="${%Testing...}"
-                method="testConnection" with="slackTeamDomain,slackToken,slackRoom"/>
+                method="testConnection" with="slackBaseURL,slackTeamDomain,slackToken,slackRoom"/>
     </f:advanced>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/global.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/global.jelly
@@ -12,6 +12,9 @@
     so it should be straightforward to find them.
   -->
 <f:section title="Global Slack Notifier Settings" name="slack">
+    <f:entry title="Base URL" help="${rootURL}/plugin/slack/help-projectConfig-slackTeamDomain.html">
+        <f:textbox field="slackBaseUrl" name="slackBaseUrl" value="${descriptor.getBaseUrl()}"/>
+    </f:entry>
     <f:entry title="Team Subdomain" help="${rootURL}/plugin/slack/help-globalConfig-slackTeamDomain.html">
         <f:textbox field="teamDomain" name="slackTeamDomain" value="${descriptor.getTeamDomain()}" />
     </f:entry>
@@ -26,6 +29,6 @@
     </f:entry>
     <f:validateButton
         title="${%Test Connection}" progress="${%Testing...}"
-        method="testConnection" with="slackTeamDomain,slackToken,slackRoom,slackBuildServerUrl" />
+        method="testConnection" with="slackBaseUrl,slackTeamDomain,slackToken,slackRoom,slackBuildServerUrl" />
   </f:section>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/global.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/global.jelly
@@ -13,7 +13,7 @@
   -->
 <f:section title="Global Slack Notifier Settings" name="slack">
     <f:entry title="Base URL" help="${rootURL}/plugin/slack/help-projectConfig-slackTeamDomain.html">
-        <f:textbox field="slackBaseUrl" name="slackBaseUrl" value="${descriptor.getBaseUrl()}"/>
+        <f:textbox field="baseUrl" name="slackBaseUrl" value="${descriptor.getBaseUrl()}"/>
     </f:entry>
     <f:entry title="Team Subdomain" help="${rootURL}/plugin/slack/help-globalConfig-slackTeamDomain.html">
         <f:textbox field="teamDomain" name="slackTeamDomain" value="${descriptor.getTeamDomain()}" />

--- a/src/main/resources/jenkins/plugins/slack/workflow/SlackSendStep/config.jelly
+++ b/src/main/resources/jenkins/plugins/slack/workflow/SlackSendStep/config.jelly
@@ -17,6 +17,9 @@
         <f:entry field="teamDomain" title="Team Domain">
             <f:textbox />
         </f:entry>
+        <f:entry field="baseUrl" title="Base URL">
+             <f:textbox />
+        </f:entry>
         <f:entry field="failOnError">
             <f:checkbox title="Fail On Error" default="false"/>
         </f:entry>

--- a/src/test/java/jenkins/plugins/slack/SlackNotifierStub.java
+++ b/src/test/java/jenkins/plugins/slack/SlackNotifierStub.java
@@ -2,12 +2,12 @@ package jenkins.plugins.slack;
 
 public class SlackNotifierStub extends SlackNotifier {
 
-    public SlackNotifierStub(String teamDomain, String authToken, String room, String buildServerUrl,
+    public SlackNotifierStub(String baseUrl, String teamDomain, String authToken, String room, String buildServerUrl,
                              String sendAs, boolean startNotification, boolean notifyAborted, boolean notifyFailure,
                              boolean notifyNotBuilt, boolean notifySuccess, boolean notifyUnstable, boolean notifyBackToNormal,
                              boolean notifyRepeatedFailure, boolean includeTestSummary, CommitInfoChoice commitInfoChoice,
                              boolean includeCustomMessage, String customMessage) {
-        super(teamDomain, authToken, room, buildServerUrl, sendAs, startNotification, notifyAborted, notifyFailure,
+        super(baseUrl, teamDomain, authToken, room, buildServerUrl, sendAs, startNotification, notifyAborted, notifyFailure,
                 notifyNotBuilt, notifySuccess, notifyUnstable, notifyBackToNormal, notifyRepeatedFailure,
                 includeTestSummary, commitInfoChoice, includeCustomMessage, customMessage);
     }
@@ -21,7 +21,7 @@ public class SlackNotifierStub extends SlackNotifier {
         }
 
         @Override
-        SlackService getSlackService(final String teamDomain, final String authToken, final String room) {
+        SlackService getSlackService(final String baseUrl, final String teamDomain, final String authToken, final String room) {
             return slackService;
         }
 

--- a/src/test/java/jenkins/plugins/slack/SlackNotifierTest.java
+++ b/src/test/java/jenkins/plugins/slack/SlackNotifierTest.java
@@ -47,7 +47,7 @@ public class SlackNotifierTest extends TestCase {
         }
         descriptor.setSlackService(slackServiceStub);
         try {
-            FormValidation result = descriptor.doTestConnection("teamDomain", "authToken", "room", "buildServerUrl");
+            FormValidation result = descriptor.doTestConnection("baseUrl","teamDomain", "authToken", "room", "buildServerUrl");
             assertEquals(result.kind, expectedResult);
         } catch (Descriptor.FormException e) {
             e.printStackTrace();

--- a/src/test/java/jenkins/plugins/slack/StandardSlackServiceStub.java
+++ b/src/test/java/jenkins/plugins/slack/StandardSlackServiceStub.java
@@ -4,8 +4,8 @@ public class StandardSlackServiceStub extends StandardSlackService {
 
     private HttpClientStub httpClientStub;
 
-    public StandardSlackServiceStub(String teamDomain, String token, String roomId) {
-        super(teamDomain, token, roomId);
+    public StandardSlackServiceStub(String baseUrl, String teamDomain, String token, String roomId) {
+        super(baseUrl, teamDomain, token, roomId);
     }
 
     @Override

--- a/src/test/java/jenkins/plugins/slack/StandardSlackServiceTest.java
+++ b/src/test/java/jenkins/plugins/slack/StandardSlackServiceTest.java
@@ -14,7 +14,7 @@ public class StandardSlackServiceTest {
      */
     @Test
     public void publishWithBadHostShouldNotRethrowExceptions() {
-        StandardSlackService service = new StandardSlackService("foo", "token", "#general");
+        StandardSlackService service = new StandardSlackService("", "foo", "token", "#general");
         service.setHost("hostvaluethatwillcausepublishtofail");
         service.publish("message");
     }
@@ -24,7 +24,7 @@ public class StandardSlackServiceTest {
      */
     @Test
     public void invalidTeamDomainShouldFail() {
-        StandardSlackService service = new StandardSlackService("my", "token", "#general");
+        StandardSlackService service = new StandardSlackService("", "my", "token", "#general");
         service.publish("message");
     }
 
@@ -33,13 +33,13 @@ public class StandardSlackServiceTest {
      */
     @Test
     public void invalidTokenShouldFail() {
-        StandardSlackService service = new StandardSlackService("tinyspeck", "token", "#general");
+        StandardSlackService service = new StandardSlackService("", "tinyspeck", "token", "#general");
         service.publish("message");
     }
 
     @Test
     public void publishToASingleRoomSendsASingleMessage() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("", "domain", "token", "#room1");
         HttpClientStub httpClientStub = new HttpClientStub();
         service.setHttpClient(httpClientStub);
         service.publish("message");
@@ -48,7 +48,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void publishToMultipleRoomsSendsAMessageToEveryRoom() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1,#room2,#room3");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("", "domain", "token", "#room1,#room2,#room3");
         HttpClientStub httpClientStub = new HttpClientStub();
         service.setHttpClient(httpClientStub);
         service.publish("message");
@@ -57,7 +57,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void successfulPublishToASingleRoomReturnsTrue() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("", "domain", "token", "#room1");
         HttpClientStub httpClientStub = new HttpClientStub();
         httpClientStub.setHttpStatus(HttpStatus.SC_OK);
         service.setHttpClient(httpClientStub);
@@ -66,7 +66,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void successfulPublishToMultipleRoomsReturnsTrue() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1,#room2,#room3");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("", "domain", "token", "#room1,#room2,#room3");
         HttpClientStub httpClientStub = new HttpClientStub();
         httpClientStub.setHttpStatus(HttpStatus.SC_OK);
         service.setHttpClient(httpClientStub);
@@ -75,7 +75,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void failedPublishToASingleRoomReturnsFalse() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("", "domain", "token", "#room1");
         HttpClientStub httpClientStub = new HttpClientStub();
         httpClientStub.setHttpStatus(HttpStatus.SC_NOT_FOUND);
         service.setHttpClient(httpClientStub);
@@ -84,7 +84,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void singleFailedPublishToMultipleRoomsReturnsFalse() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1,#room2,#room3");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("", "domain", "token", "#room1,#room2,#room3");
         HttpClientStub httpClientStub = new HttpClientStub();
         httpClientStub.setFailAlternateResponses(true);
         httpClientStub.setHttpStatus(HttpStatus.SC_OK);
@@ -94,7 +94,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void publishToEmptyRoomReturnsTrue() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("", "domain", "token", "");
         HttpClientStub httpClientStub = new HttpClientStub();
         httpClientStub.setHttpStatus(HttpStatus.SC_OK);
         service.setHttpClient(httpClientStub);

--- a/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepIntegrationTest.java
+++ b/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepIntegrationTest.java
@@ -21,6 +21,7 @@ public class SlackSendStepIntegrationTest {
         step1.setColor("good");
         step1.setChannel("#channel");
         step1.setToken("token");
+        step1.setBaseUrl("baseUrl");
         step1.setTeamDomain("teamDomain");
         step1.setFailOnError(true);
 
@@ -32,17 +33,17 @@ public class SlackSendStepIntegrationTest {
     public void test_global_config_override() throws Exception {
         WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "workflow");
         //just define message
-        job.setDefinition(new CpsFlowDefinition("slackSend(message: 'message', teamDomain: 'teamDomain', token: 'token', channel: '#channel', color: 'good');", true));
+        job.setDefinition(new CpsFlowDefinition("slackSend(message: 'message', baseUrl: 'baseUrl', teamDomain: 'teamDomain', token: 'token', channel: '#channel', color: 'good');", true));
         WorkflowRun run = jenkinsRule.assertBuildStatusSuccess(job.scheduleBuild2(0).get());
         //everything should come from step configuration
-        jenkinsRule.assertLogContains(Messages.SlackSendStepConfig(false, false, false, false), run);
+        jenkinsRule.assertLogContains(Messages.SlackSendStepConfig(false, false, false, false, false), run);
     }
 
     @Test
     public void test_fail_on_error() throws Exception {
         WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "workflow");
         //just define message
-        job.setDefinition(new CpsFlowDefinition("slackSend(message: 'message', teamDomain: 'teamDomain', token: 'token', channel: '#channel', color: 'good', failOnError: true);", true));
+        job.setDefinition(new CpsFlowDefinition("slackSend(message: 'message', baseUrl: 'baseUrl', teamDomain: 'teamDomain', token: 'token', channel: '#channel', color: 'good', failOnError: true);", true));
         WorkflowRun run = jenkinsRule.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0).get());
         //everything should come from step configuration
         jenkinsRule.assertLogContains(Messages.NotificationFailed(), run);

--- a/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepTest.java
+++ b/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepTest.java
@@ -55,6 +55,7 @@ public class SlackSendStepTest {
         SlackSendStep.SlackSendStepExecution stepExecution = spy(new SlackSendStep.SlackSendStepExecution());
         SlackSendStep slackSendStep = new SlackSendStep("message");
         slackSendStep.setToken("token");
+        slackSendStep.setBaseUrl("baseUrl");
         slackSendStep.setTeamDomain("teamDomain");
         slackSendStep.setChannel("channel");
         slackSendStep.setColor("good");
@@ -70,11 +71,11 @@ public class SlackSendStepTest {
         when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
         doNothing().when(printStreamMock).println();
 
-        when(stepExecution.getSlackService(anyString(), anyString(), anyString())).thenReturn(slackServiceMock);
+        when(stepExecution.getSlackService(anyString(), anyString(), anyString(), anyString())).thenReturn(slackServiceMock);
         when(slackServiceMock.publish(anyString(), anyString())).thenReturn(true);
 
         stepExecution.run();
-        verify(stepExecution, times(1)).getSlackService("teamDomain", "token", "channel");
+        verify(stepExecution, times(1)).getSlackService("baseUrl", "teamDomain", "token", "channel");
         verify(slackServiceMock, times(1)).publish("message", "good");
         assertFalse(stepExecution.step.isFailOnError());
     }
@@ -89,6 +90,7 @@ public class SlackSendStepTest {
 
         stepExecution.listener = taskListenerMock;
 
+        when(slackDescMock.getBaseUrl()).thenReturn("globalBaseUrl");
         when(slackDescMock.getTeamDomain()).thenReturn("globalTeamDomain");
         when(slackDescMock.getToken()).thenReturn("globalToken");
         when(slackDescMock.getRoom()).thenReturn("globalChannel");
@@ -96,11 +98,12 @@ public class SlackSendStepTest {
         when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
         doNothing().when(printStreamMock).println();
 
-        when(stepExecution.getSlackService(anyString(), anyString(), anyString())).thenReturn(slackServiceMock);
+        when(stepExecution.getSlackService(anyString(), anyString(), anyString(), anyString())).thenReturn(slackServiceMock);
 
         stepExecution.run();
-        verify(stepExecution, times(1)).getSlackService("globalTeamDomain", "globalToken", "globalChannel");
+        verify(stepExecution, times(1)).getSlackService("globalBaseUrl", "globalTeamDomain", "globalToken", "globalChannel");
         verify(slackServiceMock, times(1)).publish("message", "");
+        assertNull(stepExecution.step.getBaseUrl());
         assertNull(stepExecution.step.getTeamDomain());
         assertNull(stepExecution.step.getToken());
         assertNull(stepExecution.step.getChannel());
@@ -122,7 +125,7 @@ public class SlackSendStepTest {
         when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
         doNothing().when(printStreamMock).println();
 
-        when(stepExecution.getSlackService(anyString(), anyString(), anyString())).thenReturn(slackServiceMock);
+        when(stepExecution.getSlackService(anyString(), anyString(), anyString(), anyString())).thenReturn(slackServiceMock);
 
         stepExecution.run();
         verify(slackServiceMock, times(1)).publish("message", "");


### PR DESCRIPTION
Solution for #174 - additional configuration parameter to specify the full URL (before token) to support slack clones with compatible API, e.g. rocket.chat.
