### PR TITLE
Added support for credentials to the Slack Notifier Jenkins plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,16 @@
             <version>1.10</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>credentials</artifactId>
+            <version>1.25</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>plain-credentials</artifactId>
+            <version>1.1</version>
+        </dependency>
         <!-- only here to prevent from being included inside hpi for hudson parent, not needed by project at all -->
         <dependency>
             <groupId>log4j</groupId>

--- a/src/main/java/jenkins/plugins/slack/SlackNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/SlackNotifier.java
@@ -142,7 +142,7 @@ public class SlackNotifier extends Notifier {
         super();
         this.teamDomain = teamDomain;
         this.authToken = authToken;
-        this.authTokenCredentialId = authTokenCredentialId.trim();
+        this.authTokenCredentialId = StringUtils.trim(authTokenCredentialId);
         this.buildServerUrl = buildServerUrl;
         this.room = room;
         this.sendAs = sendAs;

--- a/src/main/java/jenkins/plugins/slack/SlackNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/SlackNotifier.java
@@ -142,7 +142,7 @@ public class SlackNotifier extends Notifier {
         super();
         this.teamDomain = teamDomain;
         this.authToken = authToken;
-        this.authTokenCredentialId = authTokenCredentialId;
+        this.authTokenCredentialId = authTokenCredentialId.trim();
         this.buildServerUrl = buildServerUrl;
         this.room = room;
         this.sendAs = sendAs;

--- a/src/main/java/jenkins/plugins/slack/StandardSlackService.java
+++ b/src/main/java/jenkins/plugins/slack/StandardSlackService.java
@@ -40,7 +40,7 @@ public class StandardSlackService implements SlackService {
         super();
         this.teamDomain = teamDomain;
         this.token = token;
-        this.authTokenCredentialId = authTokenCredentialId;
+        this.authTokenCredentialId = authTokenCredentialId.trim();
         this.roomIds = roomId.split("[,; ]+");
     }
 

--- a/src/main/java/jenkins/plugins/slack/StandardSlackService.java
+++ b/src/main/java/jenkins/plugins/slack/StandardSlackService.java
@@ -23,8 +23,10 @@ import java.util.logging.Logger;
 
 import jenkins.model.Jenkins;
 import hudson.ProxyConfiguration;
+
 import org.apache.commons.httpclient.UsernamePasswordCredentials;
 import org.apache.commons.httpclient.auth.AuthScope;
+import org.apache.commons.lang.StringUtils;
 
 public class StandardSlackService implements SlackService {
 
@@ -40,7 +42,7 @@ public class StandardSlackService implements SlackService {
         super();
         this.teamDomain = teamDomain;
         this.token = token;
-        this.authTokenCredentialId = authTokenCredentialId.trim();
+        this.authTokenCredentialId = StringUtils.trim(authTokenCredentialId);
         this.roomIds = roomId.split("[,; ]+");
     }
 

--- a/src/main/java/jenkins/plugins/slack/workflow/SlackSendStep.java
+++ b/src/main/java/jenkins/plugins/slack/workflow/SlackSendStep.java
@@ -27,6 +27,7 @@ public class SlackSendStep extends AbstractStepImpl {
     private final @Nonnull String message;
     private String color;
     private String token;
+    private String tokenCredentialId;
     private String channel;
     private String teamDomain;
     private boolean failOnError;
@@ -53,6 +54,15 @@ public class SlackSendStep extends AbstractStepImpl {
     @DataBoundSetter
     public void setToken(String token) {
         this.token = Util.fixEmpty(token);
+    }
+
+    public String getTokenCredentialId() {
+        return tokenCredentialId;
+    }
+
+    @DataBoundSetter
+    public void setTokenCredentialId(String tokenCredentialId) {
+        this.tokenCredentialId = Util.fixEmpty(tokenCredentialId);
     }
 
     public String getChannel() {
@@ -130,13 +140,14 @@ public class SlackSendStep extends AbstractStepImpl {
             SlackNotifier.DescriptorImpl slackDesc = jenkins.getDescriptorByType(SlackNotifier.DescriptorImpl.class);
             String team = step.teamDomain != null ? step.teamDomain : slackDesc.getTeamDomain();
             String token = step.token != null ? step.token : slackDesc.getToken();
+            String tokenCredentialId = step.tokenCredentialId != null ? step.tokenCredentialId : slackDesc.getTokenCredentialId();
             String channel = step.channel != null ? step.channel : slackDesc.getRoom();
             String color = step.color != null ? step.color : "";
 
             //placing in console log to simplify testing of retrieving values from global config or from step field; also used for tests
             listener.getLogger().println(Messages.SlackSendStepConfig(step.teamDomain == null, step.token == null, step.channel == null, step.color == null));
 
-            SlackService slackService = getSlackService(team, token, channel);
+            SlackService slackService = getSlackService(team, token, tokenCredentialId, channel);
             boolean publishSuccess = slackService.publish(step.message, color);
             if (!publishSuccess && step.failOnError) {
                 throw new AbortException(Messages.NotificationFailed());
@@ -147,10 +158,8 @@ public class SlackSendStep extends AbstractStepImpl {
         }
 
         //streamline unit testing
-        SlackService getSlackService(String team, String token, String channel) {
-            return new StandardSlackService(team, token, channel);
+        SlackService getSlackService(String team, String token, String tokenCredentialId, String channel) {
+            return new StandardSlackService(team, token, tokenCredentialId, channel);
         }
-
     }
-
 }

--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
@@ -59,11 +59,15 @@
             <f:textbox name="slackToken" value="${instance.getAuthToken()}"/>
         </f:entry>
 
+        <f:entry title="Integration Token Credential ID" help="${rootURL}/plugin/slack/help-projectConfig-slackTokenCredentialId.html">
+            <f:textbox name="slackTokenCredentialId" value="${instance.getAuthTokenCredentialId()}"/>
+        </f:entry>
+
         <f:entry title="Project Channel" help="${rootURL}/plugin/slack/help-projectConfig-slackRoom.html">
             <f:textbox name="slackRoom" value="${instance.getRoom()}"/>
         </f:entry>
         <f:validateButton
                 title="${%Test Connection}" progress="${%Testing...}"
-                method="testConnection" with="slackTeamDomain,slackToken,slackRoom"/>
+                method="testConnection" with="slackTeamDomain,slackToken,slackTokenCredentialId,slackRoom"/>
     </f:advanced>
 </j:jelly>

--- a/src/main/webapp/help-projectConfig-slackTokenCredentialId.html
+++ b/src/main/webapp/help-projectConfig-slackTokenCredentialId.html
@@ -1,4 +1,4 @@
 <div>
-	<p>The ID for the integration token from the Credentials plugin to be used to send notifications to Slack.  If both "Integration Token" and "Integration Token Credential ID" are set, the "Integration Token Credential ID" will take precedence for security reasons.</p>
+	<p>The ID for the integration token from the Credentials plugin to be used to send notifications to Slack.  The "Kind" of the credential must be "Secret text."  If both "Integration Token" and "Integration Token Credential ID" are set, the "Integration Token Credential ID" will take precedence for security reasons.</p>
 	<p>This overrides the global setting.</p>
 </div>

--- a/src/main/webapp/help-projectConfig-slackTokenCredentialId.html
+++ b/src/main/webapp/help-projectConfig-slackTokenCredentialId.html
@@ -1,0 +1,4 @@
+<div>
+	<p>The ID for the integration token from the Credentials plugin to be used to send notifications to Slack.  If both "Integration Token" and "Integration Token Credential ID" are set, the "Integration Token Credential ID" will take precedence for security reasons.</p>
+	<p>This overrides the global setting.</p>
+</div>

--- a/src/test/java/jenkins/plugins/slack/SlackNotifierStub.java
+++ b/src/test/java/jenkins/plugins/slack/SlackNotifierStub.java
@@ -2,12 +2,12 @@ package jenkins.plugins.slack;
 
 public class SlackNotifierStub extends SlackNotifier {
 
-    public SlackNotifierStub(String teamDomain, String authToken, String room, String buildServerUrl,
+    public SlackNotifierStub(String teamDomain, String authToken, String authTokenCredentialId, String room, String buildServerUrl,
                              String sendAs, boolean startNotification, boolean notifyAborted, boolean notifyFailure,
                              boolean notifyNotBuilt, boolean notifySuccess, boolean notifyUnstable, boolean notifyBackToNormal,
                              boolean notifyRepeatedFailure, boolean includeTestSummary, CommitInfoChoice commitInfoChoice,
                              boolean includeCustomMessage, String customMessage) {
-        super(teamDomain, authToken, room, buildServerUrl, sendAs, startNotification, notifyAborted, notifyFailure,
+        super(teamDomain, authToken, authTokenCredentialId, room, buildServerUrl, sendAs, startNotification, notifyAborted, notifyFailure,
                 notifyNotBuilt, notifySuccess, notifyUnstable, notifyBackToNormal, notifyRepeatedFailure,
                 includeTestSummary, commitInfoChoice, includeCustomMessage, customMessage);
     }
@@ -21,7 +21,7 @@ public class SlackNotifierStub extends SlackNotifier {
         }
 
         @Override
-        SlackService getSlackService(final String teamDomain, final String authToken, final String room) {
+        SlackService getSlackService(final String teamDomain, final String authToken, final String authTokenCredentialId, final String room) {
             return slackService;
         }
 

--- a/src/test/java/jenkins/plugins/slack/SlackNotifierTest.java
+++ b/src/test/java/jenkins/plugins/slack/SlackNotifierTest.java
@@ -47,7 +47,7 @@ public class SlackNotifierTest extends TestCase {
         }
         descriptor.setSlackService(slackServiceStub);
         try {
-            FormValidation result = descriptor.doTestConnection("teamDomain", "authToken", "room", "buildServerUrl");
+            FormValidation result = descriptor.doTestConnection("teamDomain", "authToken", "authTokenCredentialId", "room", "buildServerUrl");
             assertEquals(result.kind, expectedResult);
         } catch (Descriptor.FormException e) {
             e.printStackTrace();

--- a/src/test/java/jenkins/plugins/slack/StandardSlackServiceStub.java
+++ b/src/test/java/jenkins/plugins/slack/StandardSlackServiceStub.java
@@ -4,8 +4,8 @@ public class StandardSlackServiceStub extends StandardSlackService {
 
     private HttpClientStub httpClientStub;
 
-    public StandardSlackServiceStub(String teamDomain, String token, String roomId) {
-        super(teamDomain, token, roomId);
+    public StandardSlackServiceStub(String teamDomain, String token, String tokenCredentialId, String roomId) {
+        super(teamDomain, token, tokenCredentialId, roomId);
     }
 
     @Override

--- a/src/test/java/jenkins/plugins/slack/StandardSlackServiceTest.java
+++ b/src/test/java/jenkins/plugins/slack/StandardSlackServiceTest.java
@@ -13,7 +13,7 @@ public class StandardSlackServiceTest {
      */
     @Test
     public void publishWithBadHostShouldNotRethrowExceptions() {
-        StandardSlackService service = new StandardSlackService("foo", "token", "", "#general");
+        StandardSlackService service = new StandardSlackService("foo", "token", null, "#general");
         service.setHost("hostvaluethatwillcausepublishtofail");
         service.publish("message");
     }
@@ -23,7 +23,7 @@ public class StandardSlackServiceTest {
      */
     @Test
     public void invalidTeamDomainShouldFail() {
-        StandardSlackService service = new StandardSlackService("my", "token", "", "#general");
+        StandardSlackService service = new StandardSlackService("my", "token", null, "#general");
         service.publish("message");
     }
 
@@ -32,13 +32,13 @@ public class StandardSlackServiceTest {
      */
     @Test
     public void invalidTokenShouldFail() {
-        StandardSlackService service = new StandardSlackService("tinyspeck", "token", "", "#general");
+        StandardSlackService service = new StandardSlackService("tinyspeck", "token", null, "#general");
         service.publish("message");
     }
 
     @Test
     public void publishToASingleRoomSendsASingleMessage() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "", "#room1");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", null, "#room1");
         HttpClientStub httpClientStub = new HttpClientStub();
         service.setHttpClient(httpClientStub);
         service.publish("message");
@@ -47,7 +47,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void publishToMultipleRoomsSendsAMessageToEveryRoom() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "", "#room1,#room2,#room3");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", null, "#room1,#room2,#room3");
         HttpClientStub httpClientStub = new HttpClientStub();
         service.setHttpClient(httpClientStub);
         service.publish("message");
@@ -56,7 +56,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void successfulPublishToASingleRoomReturnsTrue() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "", "#room1");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", null, "#room1");
         HttpClientStub httpClientStub = new HttpClientStub();
         httpClientStub.setHttpStatus(HttpStatus.SC_OK);
         service.setHttpClient(httpClientStub);
@@ -65,7 +65,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void successfulPublishToMultipleRoomsReturnsTrue() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "", "#room1,#room2,#room3");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", null, "#room1,#room2,#room3");
         HttpClientStub httpClientStub = new HttpClientStub();
         httpClientStub.setHttpStatus(HttpStatus.SC_OK);
         service.setHttpClient(httpClientStub);
@@ -74,7 +74,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void failedPublishToASingleRoomReturnsFalse() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "", "#room1");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", null, "#room1");
         HttpClientStub httpClientStub = new HttpClientStub();
         httpClientStub.setHttpStatus(HttpStatus.SC_NOT_FOUND);
         service.setHttpClient(httpClientStub);
@@ -83,7 +83,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void singleFailedPublishToMultipleRoomsReturnsFalse() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "", "#room1,#room2,#room3");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", null, "#room1,#room2,#room3");
         HttpClientStub httpClientStub = new HttpClientStub();
         httpClientStub.setFailAlternateResponses(true);
         httpClientStub.setHttpStatus(HttpStatus.SC_OK);
@@ -93,7 +93,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void publishToEmptyRoomReturnsTrue() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "", "");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", null, "");
         HttpClientStub httpClientStub = new HttpClientStub();
         httpClientStub.setHttpStatus(HttpStatus.SC_OK);
         service.setHttpClient(httpClientStub);

--- a/src/test/java/jenkins/plugins/slack/StandardSlackServiceTest.java
+++ b/src/test/java/jenkins/plugins/slack/StandardSlackServiceTest.java
@@ -8,13 +8,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class StandardSlackServiceTest {
-
     /**
      * Publish should generally not rethrow exceptions, or it will cause a build job to fail at end.
      */
     @Test
     public void publishWithBadHostShouldNotRethrowExceptions() {
-        StandardSlackService service = new StandardSlackService("foo", "token", "#general");
+        StandardSlackService service = new StandardSlackService("foo", "token", "", "#general");
         service.setHost("hostvaluethatwillcausepublishtofail");
         service.publish("message");
     }
@@ -24,7 +23,7 @@ public class StandardSlackServiceTest {
      */
     @Test
     public void invalidTeamDomainShouldFail() {
-        StandardSlackService service = new StandardSlackService("my", "token", "#general");
+        StandardSlackService service = new StandardSlackService("my", "token", "", "#general");
         service.publish("message");
     }
 
@@ -33,13 +32,13 @@ public class StandardSlackServiceTest {
      */
     @Test
     public void invalidTokenShouldFail() {
-        StandardSlackService service = new StandardSlackService("tinyspeck", "token", "#general");
+        StandardSlackService service = new StandardSlackService("tinyspeck", "token", "", "#general");
         service.publish("message");
     }
 
     @Test
     public void publishToASingleRoomSendsASingleMessage() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "", "#room1");
         HttpClientStub httpClientStub = new HttpClientStub();
         service.setHttpClient(httpClientStub);
         service.publish("message");
@@ -48,7 +47,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void publishToMultipleRoomsSendsAMessageToEveryRoom() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1,#room2,#room3");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "", "#room1,#room2,#room3");
         HttpClientStub httpClientStub = new HttpClientStub();
         service.setHttpClient(httpClientStub);
         service.publish("message");
@@ -57,7 +56,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void successfulPublishToASingleRoomReturnsTrue() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "", "#room1");
         HttpClientStub httpClientStub = new HttpClientStub();
         httpClientStub.setHttpStatus(HttpStatus.SC_OK);
         service.setHttpClient(httpClientStub);
@@ -66,7 +65,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void successfulPublishToMultipleRoomsReturnsTrue() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1,#room2,#room3");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "", "#room1,#room2,#room3");
         HttpClientStub httpClientStub = new HttpClientStub();
         httpClientStub.setHttpStatus(HttpStatus.SC_OK);
         service.setHttpClient(httpClientStub);
@@ -75,7 +74,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void failedPublishToASingleRoomReturnsFalse() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "", "#room1");
         HttpClientStub httpClientStub = new HttpClientStub();
         httpClientStub.setHttpStatus(HttpStatus.SC_NOT_FOUND);
         service.setHttpClient(httpClientStub);
@@ -84,7 +83,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void singleFailedPublishToMultipleRoomsReturnsFalse() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1,#room2,#room3");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "", "#room1,#room2,#room3");
         HttpClientStub httpClientStub = new HttpClientStub();
         httpClientStub.setFailAlternateResponses(true);
         httpClientStub.setHttpStatus(HttpStatus.SC_OK);
@@ -94,7 +93,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void publishToEmptyRoomReturnsTrue() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "", "");
         HttpClientStub httpClientStub = new HttpClientStub();
         httpClientStub.setHttpStatus(HttpStatus.SC_OK);
         service.setHttpClient(httpClientStub);

--- a/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepIntegrationTest.java
+++ b/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepIntegrationTest.java
@@ -21,6 +21,7 @@ public class SlackSendStepIntegrationTest {
         step1.setColor("good");
         step1.setChannel("#channel");
         step1.setToken("token");
+        step1.setTokenCredentialId("tokenCredentialId");
         step1.setTeamDomain("teamDomain");
         step1.setFailOnError(true);
 
@@ -32,7 +33,7 @@ public class SlackSendStepIntegrationTest {
     public void test_global_config_override() throws Exception {
         WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "workflow");
         //just define message
-        job.setDefinition(new CpsFlowDefinition("slackSend(message: 'message', teamDomain: 'teamDomain', token: 'token', channel: '#channel', color: 'good');", true));
+        job.setDefinition(new CpsFlowDefinition("slackSend(message: 'message', teamDomain: 'teamDomain', token: 'token', tokenCredentialId: 'tokenCredentialId', channel: '#channel', color: 'good');", true));
         WorkflowRun run = jenkinsRule.assertBuildStatusSuccess(job.scheduleBuild2(0).get());
         //everything should come from step configuration
         jenkinsRule.assertLogContains(Messages.SlackSendStepConfig(false, false, false, false), run);
@@ -42,7 +43,7 @@ public class SlackSendStepIntegrationTest {
     public void test_fail_on_error() throws Exception {
         WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "workflow");
         //just define message
-        job.setDefinition(new CpsFlowDefinition("slackSend(message: 'message', teamDomain: 'teamDomain', token: 'token', channel: '#channel', color: 'good', failOnError: true);", true));
+        job.setDefinition(new CpsFlowDefinition("slackSend(message: 'message', teamDomain: 'teamDomain', token: 'token', tokenCredentialId: 'tokenCredentialId', channel: '#channel', color: 'good', failOnError: true);", true));
         WorkflowRun run = jenkinsRule.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0).get());
         //everything should come from step configuration
         jenkinsRule.assertLogContains(Messages.NotificationFailed(), run);

--- a/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepTest.java
+++ b/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.*;
 import static org.powermock.api.mockito.PowerMockito.spy;
 
 /**
- * Traditional Unit tests, allows testing null Jenkins,getInstance()
+ * Traditional Unit tests, allows testing null Jenkins.getInstance()
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Jenkins.class,SlackSendStep.class})
@@ -55,6 +55,7 @@ public class SlackSendStepTest {
         SlackSendStep.SlackSendStepExecution stepExecution = spy(new SlackSendStep.SlackSendStepExecution());
         SlackSendStep slackSendStep = new SlackSendStep("message");
         slackSendStep.setToken("token");
+        slackSendStep.setTokenCredentialId("tokenCredentialId");
         slackSendStep.setTeamDomain("teamDomain");
         slackSendStep.setChannel("channel");
         slackSendStep.setColor("good");
@@ -70,11 +71,11 @@ public class SlackSendStepTest {
         when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
         doNothing().when(printStreamMock).println();
 
-        when(stepExecution.getSlackService(anyString(), anyString(), anyString())).thenReturn(slackServiceMock);
+        when(stepExecution.getSlackService(anyString(), anyString(), anyString(), anyString())).thenReturn(slackServiceMock);
         when(slackServiceMock.publish(anyString(), anyString())).thenReturn(true);
 
         stepExecution.run();
-        verify(stepExecution, times(1)).getSlackService("teamDomain", "token", "channel");
+        verify(stepExecution, times(1)).getSlackService("teamDomain", "token", "tokenCredentialId", "channel");
         verify(slackServiceMock, times(1)).publish("message", "good");
         assertFalse(stepExecution.step.isFailOnError());
     }
@@ -91,18 +92,20 @@ public class SlackSendStepTest {
 
         when(slackDescMock.getTeamDomain()).thenReturn("globalTeamDomain");
         when(slackDescMock.getToken()).thenReturn("globalToken");
+        when(slackDescMock.getTokenCredentialId()).thenReturn("globalTokenCredentialId");
         when(slackDescMock.getRoom()).thenReturn("globalChannel");
 
         when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
         doNothing().when(printStreamMock).println();
 
-        when(stepExecution.getSlackService(anyString(), anyString(), anyString())).thenReturn(slackServiceMock);
+        when(stepExecution.getSlackService(anyString(), anyString(), anyString(), anyString())).thenReturn(slackServiceMock);
 
         stepExecution.run();
-        verify(stepExecution, times(1)).getSlackService("globalTeamDomain", "globalToken", "globalChannel");
+        verify(stepExecution, times(1)).getSlackService("globalTeamDomain", "globalToken", "globalTokenCredentialId", "globalChannel");
         verify(slackServiceMock, times(1)).publish("message", "");
         assertNull(stepExecution.step.getTeamDomain());
         assertNull(stepExecution.step.getToken());
+        assertNull(stepExecution.step.getTokenCredentialId());
         assertNull(stepExecution.step.getChannel());
         assertNull(stepExecution.step.getColor());
     }
@@ -122,7 +125,7 @@ public class SlackSendStepTest {
         when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
         doNothing().when(printStreamMock).println();
 
-        when(stepExecution.getSlackService(anyString(), anyString(), anyString())).thenReturn(slackServiceMock);
+        when(stepExecution.getSlackService(anyString(), anyString(), anyString(), anyString())).thenReturn(slackServiceMock);
 
         stepExecution.run();
         verify(slackServiceMock, times(1)).publish("message", "");


### PR DESCRIPTION
This is to address #201 and #195 

I added the field "Integration Token Credential ID" along with the "help" file. This plugin uses the credentials and plain-credentials plugin to support using secrets in the Slack notifier plugin for the Slack auth token. The secret is decrypted at the last moment possible and passed to the URL to send the message to Slack.