### PR TITLE
Link slack names in notification

### DIFF
--- a/src/main/java/jenkins/plugins/slack/StandardSlackService.java
+++ b/src/main/java/jenkins/plugins/slack/StandardSlackService.java
@@ -66,6 +66,7 @@ public class StandardSlackService implements SlackService {
 
                 json.put("channel", roomId);
                 json.put("attachments", attachments);
+                json.put("link_names", "1");
 
                 post.addParameter("payload", json.toString());
                 post.getParams().setContentCharset("UTF-8");


### PR DESCRIPTION
I usually notify me and others in "Custom Message". I want to click others' slack name to show menu for them.
So I added link_names=1 to payload. https://api.slack.com/docs/formatting#parsing_modes