### PR TITLE
Enable @here and other @mentions

### DIFF
--- a/src/main/java/jenkins/plugins/slack/StandardSlackService.java
+++ b/src/main/java/jenkins/plugins/slack/StandardSlackService.java
@@ -66,6 +66,7 @@ public class StandardSlackService implements SlackService {
 
                 json.put("channel", roomId);
                 json.put("attachments", attachments);
+                json.put("link_names", "1");
 
                 post.addParameter("payload", json.toString());
                 post.getParams().setContentCharset("UTF-8");


### PR DESCRIPTION
I tried to use @here to notify my channel of Jenkins’ failing builds, however by default Slack mutes @mentions from integrations.

To workaround that, their Support advised me to set the field `link_names` to one and it works!

Our payload should look like this:

```
  "json": {
    "text": "message goes here",
    "link_names": "1"
  }
```

So I changed the code, but I didn’t run the tests. So please, someone review it ;)