### PR TITLE
Use display-url-api for URLs to be sent in notifications

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,11 @@
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>display-url-api</artifactId>
+            <version>0.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
             <version>1.3</version>
         </dependency>

--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -17,6 +17,7 @@ import hudson.tasks.test.AbstractTestResultAction;
 import hudson.triggers.SCMTrigger;
 import hudson.util.LogTaskListener;
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -322,7 +323,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
         }
 
         public MessageBuilder appendOpenLink() {
-            String url = notifier.getBuildServerUrl() + build.getUrl();
+            String url = DisplayURLProvider.get().getRunURL(build);
             message.append(" (<").append(url).append("|Open>)");
             return this;
         }

--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/global.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/global.jelly
@@ -24,11 +24,8 @@
     <f:entry title="Channel" help="/plugin/slack/help-globalConfig-slackRoom.html">
         <f:textbox field="room" name="slackRoom" value="${descriptor.getRoom()}" />
     </f:entry>
-    <f:entry title="Build Server URL" help="/plugin/slack/help-globalConfig-slackBuildServerUrl.html">
-        <f:textbox field="buildServerUrl" name="slackBuildServerUrl" value="${descriptor.getBuildServerUrl()}" />
-    </f:entry>
     <f:validateButton
         title="${%Test Connection}" progress="${%Testing...}"
-        method="testConnection" with="slackTeamDomain,slackToken,tokenCredentialId,slackRoom,slackBuildServerUrl" />
+        method="testConnection" with="slackTeamDomain,slackToken,tokenCredentialId,slackRoom" />
   </f:section>
 </j:jelly>

--- a/src/test/java/jenkins/plugins/slack/SlackNotifierStub.java
+++ b/src/test/java/jenkins/plugins/slack/SlackNotifierStub.java
@@ -2,12 +2,12 @@ package jenkins.plugins.slack;
 
 public class SlackNotifierStub extends SlackNotifier {
 
-    public SlackNotifierStub(String teamDomain, String authToken, String authTokenCredentialId, String room, String buildServerUrl,
+    public SlackNotifierStub(String teamDomain, String authToken, String authTokenCredentialId, String room,
                              String sendAs, boolean startNotification, boolean notifyAborted, boolean notifyFailure,
                              boolean notifyNotBuilt, boolean notifySuccess, boolean notifyUnstable, boolean notifyBackToNormal,
                              boolean notifyRepeatedFailure, boolean includeTestSummary, CommitInfoChoice commitInfoChoice,
                              boolean includeCustomMessage, String customMessage) {
-        super(teamDomain, authToken, authTokenCredentialId, room, buildServerUrl, sendAs, startNotification, notifyAborted, notifyFailure,
+        super(teamDomain, authToken, authTokenCredentialId, room, sendAs, startNotification, notifyAborted, notifyFailure,
                 notifyNotBuilt, notifySuccess, notifyUnstable, notifyBackToNormal, notifyRepeatedFailure,
                 includeTestSummary, commitInfoChoice, includeCustomMessage, customMessage);
     }

--- a/src/test/java/jenkins/plugins/slack/SlackNotifierTest.java
+++ b/src/test/java/jenkins/plugins/slack/SlackNotifierTest.java
@@ -3,10 +3,12 @@ package jenkins.plugins.slack;
 import hudson.model.Descriptor;
 import hudson.util.FormValidation;
 import junit.framework.TestCase;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.jvnet.hudson.test.JenkinsRule;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -18,6 +20,9 @@ public class SlackNotifierTest extends TestCase {
     private SlackServiceStub slackServiceStub;
     private boolean response;
     private FormValidation.Kind expectedResult;
+
+    @Rule
+    public final JenkinsRule rule = new JenkinsRule();
 
     @Before
     @Override
@@ -47,7 +52,7 @@ public class SlackNotifierTest extends TestCase {
         }
         descriptor.setSlackService(slackServiceStub);
         try {
-            FormValidation result = descriptor.doTestConnection("teamDomain", "authToken", "authTokenCredentialId", "room", "buildServerUrl");
+            FormValidation result = descriptor.doTestConnection("teamDomain", "authToken", "authTokenCredentialId", "room");
             assertEquals(result.kind, expectedResult);
         } catch (Descriptor.FormException e) {
             e.printStackTrace();

--- a/src/test/java/jenkins/plugins/slack/config/BackwordsCompatible_1_8_SlackNotifierTest.java
+++ b/src/test/java/jenkins/plugins/slack/config/BackwordsCompatible_1_8_SlackNotifierTest.java
@@ -42,7 +42,6 @@ public class BackwordsCompatible_1_8_SlackNotifierTest {
 
         assertEquals("jenkins-slack-plugin", notifier.getTeamDomain());
         assertEquals("auth-token-for-test", notifier.getAuthToken());
-        assertEquals("http://localhost:8080/", notifier.getBuildServerUrl());
         assertEquals("#slack-plugin-testing", notifier.getRoom());
 
         assertFalse(notifier.getStartNotification());
@@ -69,7 +68,6 @@ public class BackwordsCompatible_1_8_SlackNotifierTest {
 
         assertEquals("jenkins-slack-plugin", notifier.getTeamDomain());
         assertEquals("auth-token-for-test", notifier.getAuthToken());
-        assertEquals("http://localhost:8080/", notifier.getBuildServerUrl());
         assertEquals("#slack-plugin-testing", notifier.getRoom());
 
         assertFalse(notifier.getStartNotification());
@@ -96,7 +94,6 @@ public class BackwordsCompatible_1_8_SlackNotifierTest {
 
         assertEquals("", notifier.getTeamDomain());
         assertEquals("", notifier.getAuthToken());
-        assertEquals(j.getURL().toString(), notifier.getBuildServerUrl());
         assertEquals("", notifier.getRoom());
 
         assertFalse(notifier.getStartNotification());
@@ -151,7 +148,6 @@ public class BackwordsCompatible_1_8_SlackNotifierTest {
 
         assertEquals("", notifier.getTeamDomain());
         assertEquals("", notifier.getAuthToken());
-        assertEquals(j.getURL().toString(), notifier.getBuildServerUrl());
         assertEquals("", notifier.getRoom());
 
         assertTrue(notifier.getStartNotification());


### PR DESCRIPTION
This will allow [Blue Ocean](https://jenkins.io/blog/2016/05/26/introducing-blue-ocean/) to change the display URLs in Slack notifications so that it points to the Blue Ocean UI. 

Waiting on https://issues.jenkins-ci.org/browse/HOSTING-179 to be approved and a release to be run.

I'm not sure why this plugin has its own setting for the build server root URL - this should always come from what the administrator has configured within Jenkins. I've removed this option from the Slack global settings.

@jenkinsci/code-reviewers 
