### PR TITLE
Add Credentials Support with credentials select widget [JENKINS-35503]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,27 @@
-# Slack plugin for Jenkins - [![Build Status][jenkins-status]][jenkins-builds] [![Slack Signup][slack-badge]][slack-signup]
+Slack plugin for Jenkins  [![Build Status][jenkins-status]][jenkins-builds] [![Slack Signup][slack-badge]][slack-signup]
+----------------------------------------------------------------
 
-Started with a fork of the HipChat plugin:
+Provides Jenkins notification integration with Slack.
 
-https://github.com/jlewallen/jenkins-hipchat-plugin
+## Install Instructions
 
-Which was, in turn, a fork of the Campfire plugin.
+1. Get a Slack account: https://slack.com/
+2. Configure the Jenkins integration: https://my.slack.com/services/new/jenkins-ci
+3. Install this plugin on your Jenkins server
+4. Configure it in your Jenkins job (and optionally as global configuration) and **add it as a Post-build action**.
+
+#### Security
+
+Use Jenkins Credentials and a credential ID to configure the Slack integration token. It is a security risk to expose your integration token using the previous *Integration Token* setting.
+
+Create a new ***Secret text*** credential:
+![image](https://cloud.githubusercontent.com/assets/983526/17971588/6c26dfa0-6aa9-11e6-808c-3e139446e013.png)
+
+
+Select that credential as the value for the ***Integration Token Credential ID*** field:
+![image](https://cloud.githubusercontent.com/assets/983526/17971458/ec296bf6-6aa8-11e6-8d19-06d9f1c9d611.png)
+
+#### Jenkins Pipeline Support
 
 Includes [Jenkins Pipeline](https://github.com/jenkinsci/workflow-plugin) support as of version 2.0:
 
@@ -12,14 +29,7 @@ Includes [Jenkins Pipeline](https://github.com/jenkinsci/workflow-plugin) suppor
 slackSend color: 'good', message: 'Message from Jenkins Pipeline'
 ```
 
-# Jenkins Instructions
-
-1. Get a Slack account: https://slack.com/
-2. Configure the Jenkins integration: https://my.slack.com/services/new/jenkins-ci
-3. Install this plugin on your Jenkins server
-4. Configure it in your Jenkins job and **add it as a Post-build action**.
-
-# Developer instructions
+### Developer instructions
 
 Install Maven and JDK.  This was last build with Maven 3.2.5 and OpenJDK
 1.7.0\_75 on KUbuntu 14.04.

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,16 @@
             <version>1.10</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>credentials</artifactId>
+            <version>1.25</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>plain-credentials</artifactId>
+            <version>1.1</version>
+        </dependency>
         <!-- only here to prevent from being included inside hpi for hudson parent, not needed by project at all -->
         <dependency>
             <groupId>log4j</groupId>

--- a/src/main/java/jenkins/plugins/slack/SlackNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/SlackNotifier.java
@@ -284,6 +284,12 @@ public class SlackNotifier extends Notifier {
                     );
         }
 
+        //WARN users that they should not use the plain/exposed token, but rather the token credential id
+        public FormValidation doCheckToken(@QueryParameter String value) {
+            //always show the warning - TODO investigate if there is a better way to handle this
+            return FormValidation.warning("Exposing your Integration Token is a security risk. Please use the Integration Token Credential ID");
+        }
+
         public boolean isApplicable(Class<? extends AbstractProject> aClass) {
             return true;
         }

--- a/src/main/java/jenkins/plugins/slack/SlackNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/SlackNotifier.java
@@ -33,6 +33,7 @@ public class SlackNotifier extends Notifier {
 
     private String teamDomain;
     private String authToken;
+    private String authTokenCredentialId;
     private String buildServerUrl;
     private String room;
     private String sendAs;
@@ -64,6 +65,10 @@ public class SlackNotifier extends Notifier {
 
     public String getAuthToken() {
         return authToken;
+    }
+
+    public String getAuthTokenCredentialId() {
+        return authTokenCredentialId;
     }
 
     public String getBuildServerUrl() {
@@ -129,7 +134,7 @@ public class SlackNotifier extends Notifier {
     }
 
     @DataBoundConstructor
-    public SlackNotifier(final String teamDomain, final String authToken, final String room, final String buildServerUrl,
+    public SlackNotifier(final String teamDomain, final String authToken, final String authTokenCredentialId, final String room, final String buildServerUrl,
                          final String sendAs, final boolean startNotification, final boolean notifyAborted, final boolean notifyFailure,
                          final boolean notifyNotBuilt, final boolean notifySuccess, final boolean notifyUnstable, final boolean notifyBackToNormal,
                          final boolean notifyRepeatedFailure, final boolean includeTestSummary, CommitInfoChoice commitInfoChoice,
@@ -137,6 +142,7 @@ public class SlackNotifier extends Notifier {
         super();
         this.teamDomain = teamDomain;
         this.authToken = authToken;
+        this.authTokenCredentialId = StringUtils.trim(authTokenCredentialId);
         this.buildServerUrl = buildServerUrl;
         this.room = room;
         this.sendAs = sendAs;
@@ -167,6 +173,10 @@ public class SlackNotifier extends Notifier {
         if (StringUtils.isEmpty(authToken)) {
             authToken = getDescriptor().getToken();
         }
+        String authTokenCredentialId = this.authTokenCredentialId;
+        if (StringUtils.isEmpty(authTokenCredentialId)) {
+            authTokenCredentialId = getDescriptor().getTokenCredentialId();
+        }
         String room = this.room;
         if (StringUtils.isEmpty(room)) {
             room = getDescriptor().getRoom();
@@ -181,9 +191,10 @@ public class SlackNotifier extends Notifier {
         }
         teamDomain = env.expand(teamDomain);
         authToken = env.expand(authToken);
+        authTokenCredentialId = env.expand(authTokenCredentialId);
         room = env.expand(room);
 
-        return new StandardSlackService(teamDomain, authToken, room);
+        return new StandardSlackService(teamDomain, authToken, authTokenCredentialId, room);
     }
 
     @Override
@@ -210,6 +221,7 @@ public class SlackNotifier extends Notifier {
 
         private String teamDomain;
         private String token;
+        private String tokenCredentialId;
         private String room;
         private String buildServerUrl;
         private String sendAs;
@@ -226,6 +238,10 @@ public class SlackNotifier extends Notifier {
 
         public String getToken() {
             return token;
+        }
+
+        public String getTokenCredentialId() {
+            return tokenCredentialId;
         }
 
         public String getRoom() {
@@ -254,6 +270,7 @@ public class SlackNotifier extends Notifier {
         public SlackNotifier newInstance(StaplerRequest sr, JSONObject json) {
             String teamDomain = sr.getParameter("slackTeamDomain");
             String token = sr.getParameter("slackToken");
+            String tokenCredentialId = sr.getParameter("slackTokenCredentialId");
             String room = sr.getParameter("slackRoom");
             boolean startNotification = "true".equals(sr.getParameter("slackStartNotification"));
             boolean notifySuccess = "true".equals(sr.getParameter("slackNotifySuccess"));
@@ -267,7 +284,7 @@ public class SlackNotifier extends Notifier {
             CommitInfoChoice commitInfoChoice = CommitInfoChoice.forDisplayName(sr.getParameter("slackCommitInfoChoice"));
             boolean includeCustomMessage = "on".equals(sr.getParameter("includeCustomMessage"));
             String customMessage = sr.getParameter("customMessage");
-            return new SlackNotifier(teamDomain, token, room, buildServerUrl, sendAs, startNotification, notifyAborted,
+            return new SlackNotifier(teamDomain, token, tokenCredentialId, room, buildServerUrl, sendAs, startNotification, notifyAborted,
                     notifyFailure, notifyNotBuilt, notifySuccess, notifyUnstable, notifyBackToNormal, notifyRepeatedFailure,
                     includeTestSummary, commitInfoChoice, includeCustomMessage, customMessage);
         }
@@ -276,6 +293,7 @@ public class SlackNotifier extends Notifier {
         public boolean configure(StaplerRequest sr, JSONObject formData) throws FormException {
             teamDomain = sr.getParameter("slackTeamDomain");
             token = sr.getParameter("slackToken");
+            tokenCredentialId = sr.getParameter("slackTokenCredentialId");
             room = sr.getParameter("slackRoom");
             buildServerUrl = sr.getParameter("slackBuildServerUrl");
             sendAs = sr.getParameter("slackSendAs");
@@ -290,8 +308,8 @@ public class SlackNotifier extends Notifier {
             return super.configure(sr, formData);
         }
 
-        SlackService getSlackService(final String teamDomain, final String authToken, final String room) {
-            return new StandardSlackService(teamDomain, authToken, room);
+        SlackService getSlackService(final String teamDomain, final String authToken, final String authTokenCredentialId, final String room) {
+            return new StandardSlackService(teamDomain, authToken, authTokenCredentialId, room);
         }
 
         @Override
@@ -301,6 +319,7 @@ public class SlackNotifier extends Notifier {
 
         public FormValidation doTestConnection(@QueryParameter("slackTeamDomain") final String teamDomain,
                                                @QueryParameter("slackToken") final String authToken,
+                                               @QueryParameter("slackTokenCredentialId") final String authTokenCredentialId,
                                                @QueryParameter("slackRoom") final String room,
                                                @QueryParameter("slackBuildServerUrl") final String buildServerUrl) throws FormException {
             try {
@@ -312,6 +331,10 @@ public class SlackNotifier extends Notifier {
                 if (StringUtils.isEmpty(targetToken)) {
                     targetToken = this.token;
                 }
+                String targetTokenCredentialId = authTokenCredentialId;
+                if (StringUtils.isEmpty(targetTokenCredentialId)) {
+                    targetTokenCredentialId = this.tokenCredentialId;
+                }
                 String targetRoom = room;
                 if (StringUtils.isEmpty(targetRoom)) {
                     targetRoom = this.room;
@@ -320,7 +343,7 @@ public class SlackNotifier extends Notifier {
                 if (StringUtils.isEmpty(targetBuildServerUrl)) {
                     targetBuildServerUrl = this.buildServerUrl;
                 }
-                SlackService testSlackService = getSlackService(targetDomain, targetToken, targetRoom);
+                SlackService testSlackService = getSlackService(targetDomain, targetToken, targetTokenCredentialId, targetRoom);
                 String message = "Slack/Jenkins plugin: you're all set on " + targetBuildServerUrl;
                 boolean success = testSlackService.publish(message, "good");
                 return success ? FormValidation.ok("Success") : FormValidation.error("Failure");

--- a/src/main/java/jenkins/plugins/slack/StandardSlackService.java
+++ b/src/main/java/jenkins/plugins/slack/StandardSlackService.java
@@ -1,19 +1,32 @@
 package jenkins.plugins.slack;
 
+import hudson.security.ACL;
+
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.methods.PostMethod;
 
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+
+import com.cloudbees.plugins.credentials.CredentialsMatcher;
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+
 import org.json.JSONObject;
 import org.json.JSONArray;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import jenkins.model.Jenkins;
 import hudson.ProxyConfiguration;
+
 import org.apache.commons.httpclient.UsernamePasswordCredentials;
 import org.apache.commons.httpclient.auth.AuthScope;
+import org.apache.commons.lang.StringUtils;
 
 public class StandardSlackService implements SlackService {
 
@@ -22,12 +35,14 @@ public class StandardSlackService implements SlackService {
     private String host = "slack.com";
     private String teamDomain;
     private String token;
+    private String authTokenCredentialId;
     private String[] roomIds;
 
-    public StandardSlackService(String teamDomain, String token, String roomId) {
+    public StandardSlackService(String teamDomain, String token, String authTokenCredentialId, String roomId) {
         super();
         this.teamDomain = teamDomain;
         this.token = token;
+        this.authTokenCredentialId = StringUtils.trim(authTokenCredentialId);
         this.roomIds = roomId.split("[,; ]+");
     }
 
@@ -38,7 +53,7 @@ public class StandardSlackService implements SlackService {
     public boolean publish(String message, String color) {
         boolean result = true;
         for (String roomId : roomIds) {
-            String url = "https://" + teamDomain + "." + host + "/services/hooks/jenkins-ci?token=" + token;
+            String url = "https://" + teamDomain + "." + host + "/services/hooks/jenkins-ci?token=" + getTokenToUse();
             logger.info("Posting: to " + roomId + " on " + teamDomain + " using " + url +": " + message + " " + color);
             HttpClient client = getHttpClient();
             PostMethod post = new PostMethod(url);
@@ -87,6 +102,26 @@ public class StandardSlackService implements SlackService {
             }
         }
         return result;
+    }
+
+    private String getTokenToUse() {
+        if (authTokenCredentialId != null && !authTokenCredentialId.isEmpty()) {
+            StringCredentials credentials = lookupCredentials(authTokenCredentialId);
+            if (credentials != null) {
+                logger.info("Using Integration Token Credential ID.");
+                return credentials.getSecret().getPlainText();
+            }
+        }
+
+        logger.info("Using Integration Token.");
+
+        return token;
+    }
+
+    private StringCredentials lookupCredentials(String credentialId) {
+        List<StringCredentials> credentials = CredentialsProvider.lookupCredentials(StringCredentials.class, Jenkins.getInstance(), ACL.SYSTEM, Collections.<DomainRequirement>emptyList());
+        CredentialsMatcher matcher = CredentialsMatchers.withId(credentialId);
+        return CredentialsMatchers.firstOrNull(credentials, matcher);
     }
 
     protected HttpClient getHttpClient() {

--- a/src/main/java/jenkins/plugins/slack/workflow/SlackSendStep.java
+++ b/src/main/java/jenkins/plugins/slack/workflow/SlackSendStep.java
@@ -8,6 +8,7 @@ import hudson.Util;
 import hudson.model.Project;
 import hudson.model.TaskListener;
 import hudson.security.ACL;
+import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
 import jenkins.plugins.slack.Messages;
@@ -22,6 +23,7 @@ import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
 
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
@@ -135,6 +137,12 @@ public class SlackSendStep extends AbstractStepImpl {
                             ACL.SYSTEM,
                             new HostnameRequirement("*.slack.com"))
                     );
+        }
+
+        //WARN users that they should not use the plain/exposed token, but rather the token credential id
+        public FormValidation doCheckToken(@QueryParameter String value) {
+            //always show the warning - TODO investigate if there is a better way to handle this
+            return FormValidation.warning("Exposing your Integration Token is a security risk. Please use the Integration Token Credential ID");
         }
     }
 

--- a/src/main/java/jenkins/plugins/slack/workflow/SlackSendStep.java
+++ b/src/main/java/jenkins/plugins/slack/workflow/SlackSendStep.java
@@ -27,6 +27,7 @@ public class SlackSendStep extends AbstractStepImpl {
     private final @Nonnull String message;
     private String color;
     private String token;
+    private String tokenCredentialId;
     private String channel;
     private String teamDomain;
     private boolean failOnError;
@@ -53,6 +54,15 @@ public class SlackSendStep extends AbstractStepImpl {
     @DataBoundSetter
     public void setToken(String token) {
         this.token = Util.fixEmpty(token);
+    }
+
+    public String getTokenCredentialId() {
+        return tokenCredentialId;
+    }
+
+    @DataBoundSetter
+    public void setTokenCredentialId(String tokenCredentialId) {
+        this.tokenCredentialId = Util.fixEmpty(tokenCredentialId);
     }
 
     public String getChannel() {
@@ -130,13 +140,14 @@ public class SlackSendStep extends AbstractStepImpl {
             SlackNotifier.DescriptorImpl slackDesc = jenkins.getDescriptorByType(SlackNotifier.DescriptorImpl.class);
             String team = step.teamDomain != null ? step.teamDomain : slackDesc.getTeamDomain();
             String token = step.token != null ? step.token : slackDesc.getToken();
+            String tokenCredentialId = step.tokenCredentialId != null ? step.tokenCredentialId : slackDesc.getTokenCredentialId();
             String channel = step.channel != null ? step.channel : slackDesc.getRoom();
             String color = step.color != null ? step.color : "";
 
             //placing in console log to simplify testing of retrieving values from global config or from step field; also used for tests
             listener.getLogger().println(Messages.SlackSendStepConfig(step.teamDomain == null, step.token == null, step.channel == null, step.color == null));
 
-            SlackService slackService = getSlackService(team, token, channel);
+            SlackService slackService = getSlackService(team, token, tokenCredentialId, channel);
             boolean publishSuccess = slackService.publish(step.message, color);
             if (!publishSuccess && step.failOnError) {
                 throw new AbortException(Messages.NotificationFailed());
@@ -147,10 +158,8 @@ public class SlackSendStep extends AbstractStepImpl {
         }
 
         //streamline unit testing
-        SlackService getSlackService(String team, String token, String channel) {
-            return new StandardSlackService(team, token, channel);
+        SlackService getSlackService(String team, String token, String tokenCredentialId, String channel) {
+            return new StandardSlackService(team, token, tokenCredentialId, channel);
         }
-
     }
-
 }

--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
@@ -1,5 +1,5 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
     <f:entry title="Notify Build Start">
         <f:checkbox name="slackStartNotification" value="true" checked="${instance.getStartNotification()}"/>
     </f:entry>
@@ -38,7 +38,7 @@
         </f:entry>
 
         <f:optionalBlock name="includeCustomMessage" title="Include Custom Message" checked="${instance.includeCustomMessage()}">
-            <f:entry title="Custom Message" help="${rootURL}/plugin/slack/help-projectConfig-slackCustomMessage.html">
+            <f:entry title="Custom Message" help="/plugin/slack/help-projectConfig-slackCustomMessage.html">
                 <f:textarea name="customMessage" value="${instance.getCustomMessage()}"/>
             </f:entry>
         </f:optionalBlock>
@@ -51,23 +51,23 @@
             </select>
         </f:entry>
 
-        <f:entry title="Team Subdomain" help="${rootURL}/plugin/slack/help-projectConfig-slackTeamDomain.html">
+        <f:entry title="Team Subdomain" help="/plugin/slack/help-projectConfig-slackTeamDomain.html">
             <f:textbox name="slackTeamDomain" value="${instance.getTeamDomain()}"/>
         </f:entry>
 
-        <f:entry title="Integration Token" help="${rootURL}/plugin/slack/help-projectConfig-slackToken.html">
+        <f:entry title="Integration Token" help="/plugin/slack/help-projectConfig-slackToken.html">
             <f:textbox name="slackToken" value="${instance.getAuthToken()}"/>
         </f:entry>
 
-        <f:entry title="Integration Token Credential ID" help="${rootURL}/plugin/slack/help-projectConfig-slackTokenCredentialId.html">
-            <f:textbox name="slackTokenCredentialId" value="${instance.getAuthTokenCredentialId()}"/>
+        <f:entry title="Integration Token Credential ID" help="/plugin/slack/help-projectConfig-slackTokenCredentialId.html" field="tokenCredentialId" name="tokenCredentialId" >
+            <c:select value="${instance.getAuthTokenCredentialId()}"/>
         </f:entry>
 
-        <f:entry title="Project Channel" help="${rootURL}/plugin/slack/help-projectConfig-slackRoom.html">
+        <f:entry title="Project Channel" help="/plugin/slack/help-projectConfig-slackRoom.html">
             <f:textbox name="slackRoom" value="${instance.getRoom()}"/>
         </f:entry>
         <f:validateButton
                 title="${%Test Connection}" progress="${%Testing...}"
-                method="testConnection" with="slackTeamDomain,slackToken,slackTokenCredentialId,slackRoom"/>
+                method="testConnection" with="slackTeamDomain,slackToken,tokenCredentialId,slackRoom"/>
     </f:advanced>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
@@ -59,11 +59,15 @@
             <f:textbox name="slackToken" value="${instance.getAuthToken()}"/>
         </f:entry>
 
+        <f:entry title="Integration Token Credential ID" help="${rootURL}/plugin/slack/help-projectConfig-slackTokenCredentialId.html">
+            <f:textbox name="slackTokenCredentialId" value="${instance.getAuthTokenCredentialId()}"/>
+        </f:entry>
+
         <f:entry title="Project Channel" help="${rootURL}/plugin/slack/help-projectConfig-slackRoom.html">
             <f:textbox name="slackRoom" value="${instance.getRoom()}"/>
         </f:entry>
         <f:validateButton
                 title="${%Test Connection}" progress="${%Testing...}"
-                method="testConnection" with="slackTeamDomain,slackToken,slackRoom"/>
+                method="testConnection" with="slackTeamDomain,slackToken,slackTokenCredentialId,slackRoom"/>
     </f:advanced>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
@@ -56,7 +56,7 @@
         </f:entry>
 
         <f:entry title="Integration Token" help="/plugin/slack/help-projectConfig-slackToken.html">
-            <f:textbox name="slackToken" value="${instance.getAuthToken()}"/>
+            <f:textbox field="token" name="slackToken" value="${instance.getAuthToken()}"/>
         </f:entry>
 
         <f:entry title="Integration Token Credential ID" help="/plugin/slack/help-projectConfig-slackTokenCredentialId.html" field="tokenCredentialId" name="tokenCredentialId" >

--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/global.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/global.jelly
@@ -1,4 +1,4 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
   <!--
     This Jelly script is used to produce the global configuration option.
 
@@ -12,20 +12,23 @@
     so it should be straightforward to find them.
   -->
 <f:section title="Global Slack Notifier Settings" name="slack">
-    <f:entry title="Team Subdomain" help="${rootURL}/plugin/slack/help-globalConfig-slackTeamDomain.html">
+    <f:entry title="Team Subdomain" help="/plugin/slack/help-globalConfig-slackTeamDomain.html">
         <f:textbox field="teamDomain" name="slackTeamDomain" value="${descriptor.getTeamDomain()}" />
     </f:entry>
-    <f:entry title="Integration Token" help="${rootURL}/plugin/slack/help-globalConfig-slackToken.html">
+    <f:entry title="Integration Token" help="/plugin/slack/help-globalConfig-slackToken.html">
         <f:textbox field="token" name="slackToken" value="${descriptor.getToken()}" />
     </f:entry>
-    <f:entry title="Channel" help="${rootURL}/plugin/slack/help-globalConfig-slackRoom.html">
+    <f:entry title="Integration Token Credential ID" field="tokenCredentialId" name="tokenCredentialId" help="/plugin/slack/help-globalConfig-tokenCredentialId.html">
+        <c:select/>
+    </f:entry>
+    <f:entry title="Channel" help="/plugin/slack/help-globalConfig-slackRoom.html">
         <f:textbox field="room" name="slackRoom" value="${descriptor.getRoom()}" />
     </f:entry>
-    <f:entry title="Build Server URL" help="${rootURL}/plugin/slack/help-globalConfig-slackBuildServerUrl.html">
+    <f:entry title="Build Server URL" help="/plugin/slack/help-globalConfig-slackBuildServerUrl.html">
         <f:textbox field="buildServerUrl" name="slackBuildServerUrl" value="${descriptor.getBuildServerUrl()}" />
     </f:entry>
     <f:validateButton
         title="${%Test Connection}" progress="${%Testing...}"
-        method="testConnection" with="slackTeamDomain,slackToken,slackRoom,slackBuildServerUrl" />
+        method="testConnection" with="slackTeamDomain,slackToken,tokenCredentialId,slackRoom,slackBuildServerUrl" />
   </f:section>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/slack/workflow/SlackSendStep/config.jelly
+++ b/src/main/resources/jenkins/plugins/slack/workflow/SlackSendStep/config.jelly
@@ -11,7 +11,7 @@
         <f:entry field="channel" title="Channel">
             <f:textbox />
         </f:entry>
-        <f:entry field="tokenCredentialId" title="Integration Token">
+        <f:entry field="tokenCredentialId" title="Integration Token Credential ID">
              <c:select/>
         </f:entry>
         <f:entry field="token" title="Integration Token">

--- a/src/main/resources/jenkins/plugins/slack/workflow/SlackSendStep/config.jelly
+++ b/src/main/resources/jenkins/plugins/slack/workflow/SlackSendStep/config.jelly
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
     <f:entry field="message" title="Message">
         <f:textbox/>
     </f:entry>
@@ -10,6 +10,9 @@
     <f:advanced>
         <f:entry field="channel" title="Channel">
             <f:textbox />
+        </f:entry>
+        <f:entry field="tokenCredentialId" title="Integration Token">
+             <c:select/>
         </f:entry>
         <f:entry field="token" title="Integration Token">
             <f:textbox />

--- a/src/main/resources/jenkins/plugins/slack/workflow/SlackSendStep/help-tokenCredentialId.html
+++ b/src/main/resources/jenkins/plugins/slack/workflow/SlackSendStep/help-tokenCredentialId.html
@@ -1,0 +1,4 @@
+<div>
+    <p>The ID for the integration token from the Credentials plugin to be used to send notifications to Slack.  The "Kind" of the credential must be "Secret text."  If both "Integration Token" and "Integration Token Credential ID" are set, the "Integration Token Credential ID" will take precedence for security reasons.</p>
+    <p>This overrides the global setting.</p>
+</div>

--- a/src/main/webapp/help-globalConfig-tokenCredentialId.html
+++ b/src/main/webapp/help-globalConfig-tokenCredentialId.html
@@ -1,0 +1,3 @@
+<div>
+	<p>The ID for the integration token from the Credentials plugin to be used to send notifications to Slack.  The "Kind" of the credential must be "Secret text."  If both "Integration Token" and "Integration Token Credential ID" are set, the "Integration Token Credential ID" will take precedence for security reasons.</p>
+</div>

--- a/src/main/webapp/help-projectConfig-slackTokenCredentialId.html
+++ b/src/main/webapp/help-projectConfig-slackTokenCredentialId.html
@@ -1,0 +1,4 @@
+<div>
+	<p>The ID for the integration token from the Credentials plugin to be used to send notifications to Slack.  The "Kind" of the credential must be "Secret text."  If both "Integration Token" and "Integration Token Credential ID" are set, the "Integration Token Credential ID" will take precedence for security reasons.</p>
+	<p>This overrides the global setting.</p>
+</div>

--- a/src/test/java/jenkins/plugins/slack/SlackNotifierStub.java
+++ b/src/test/java/jenkins/plugins/slack/SlackNotifierStub.java
@@ -2,12 +2,12 @@ package jenkins.plugins.slack;
 
 public class SlackNotifierStub extends SlackNotifier {
 
-    public SlackNotifierStub(String teamDomain, String authToken, String room, String buildServerUrl,
+    public SlackNotifierStub(String teamDomain, String authToken, String authTokenCredentialId, String room, String buildServerUrl,
                              String sendAs, boolean startNotification, boolean notifyAborted, boolean notifyFailure,
                              boolean notifyNotBuilt, boolean notifySuccess, boolean notifyUnstable, boolean notifyBackToNormal,
                              boolean notifyRepeatedFailure, boolean includeTestSummary, CommitInfoChoice commitInfoChoice,
                              boolean includeCustomMessage, String customMessage) {
-        super(teamDomain, authToken, room, buildServerUrl, sendAs, startNotification, notifyAborted, notifyFailure,
+        super(teamDomain, authToken, authTokenCredentialId, room, buildServerUrl, sendAs, startNotification, notifyAborted, notifyFailure,
                 notifyNotBuilt, notifySuccess, notifyUnstable, notifyBackToNormal, notifyRepeatedFailure,
                 includeTestSummary, commitInfoChoice, includeCustomMessage, customMessage);
     }
@@ -21,7 +21,7 @@ public class SlackNotifierStub extends SlackNotifier {
         }
 
         @Override
-        SlackService getSlackService(final String teamDomain, final String authToken, final String room) {
+        SlackService getSlackService(final String teamDomain, final String authToken, final String authTokenCredentialId, final String room) {
             return slackService;
         }
 

--- a/src/test/java/jenkins/plugins/slack/SlackNotifierTest.java
+++ b/src/test/java/jenkins/plugins/slack/SlackNotifierTest.java
@@ -47,7 +47,7 @@ public class SlackNotifierTest extends TestCase {
         }
         descriptor.setSlackService(slackServiceStub);
         try {
-            FormValidation result = descriptor.doTestConnection("teamDomain", "authToken", "room", "buildServerUrl");
+            FormValidation result = descriptor.doTestConnection("teamDomain", "authToken", "authTokenCredentialId", "room", "buildServerUrl");
             assertEquals(result.kind, expectedResult);
         } catch (Descriptor.FormException e) {
             e.printStackTrace();

--- a/src/test/java/jenkins/plugins/slack/StandardSlackServiceStub.java
+++ b/src/test/java/jenkins/plugins/slack/StandardSlackServiceStub.java
@@ -4,8 +4,8 @@ public class StandardSlackServiceStub extends StandardSlackService {
 
     private HttpClientStub httpClientStub;
 
-    public StandardSlackServiceStub(String teamDomain, String token, String roomId) {
-        super(teamDomain, token, roomId);
+    public StandardSlackServiceStub(String teamDomain, String token, String tokenCredentialId, String roomId) {
+        super(teamDomain, token, tokenCredentialId, roomId);
     }
 
     @Override

--- a/src/test/java/jenkins/plugins/slack/StandardSlackServiceTest.java
+++ b/src/test/java/jenkins/plugins/slack/StandardSlackServiceTest.java
@@ -8,13 +8,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class StandardSlackServiceTest {
-
     /**
      * Publish should generally not rethrow exceptions, or it will cause a build job to fail at end.
      */
     @Test
     public void publishWithBadHostShouldNotRethrowExceptions() {
-        StandardSlackService service = new StandardSlackService("foo", "token", "#general");
+        StandardSlackService service = new StandardSlackService("foo", "token", null, "#general");
         service.setHost("hostvaluethatwillcausepublishtofail");
         service.publish("message");
     }
@@ -24,7 +23,7 @@ public class StandardSlackServiceTest {
      */
     @Test
     public void invalidTeamDomainShouldFail() {
-        StandardSlackService service = new StandardSlackService("my", "token", "#general");
+        StandardSlackService service = new StandardSlackService("my", "token", null, "#general");
         service.publish("message");
     }
 
@@ -33,13 +32,13 @@ public class StandardSlackServiceTest {
      */
     @Test
     public void invalidTokenShouldFail() {
-        StandardSlackService service = new StandardSlackService("tinyspeck", "token", "#general");
+        StandardSlackService service = new StandardSlackService("tinyspeck", "token", null, "#general");
         service.publish("message");
     }
 
     @Test
     public void publishToASingleRoomSendsASingleMessage() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", null, "#room1");
         HttpClientStub httpClientStub = new HttpClientStub();
         service.setHttpClient(httpClientStub);
         service.publish("message");
@@ -48,7 +47,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void publishToMultipleRoomsSendsAMessageToEveryRoom() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1,#room2,#room3");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", null, "#room1,#room2,#room3");
         HttpClientStub httpClientStub = new HttpClientStub();
         service.setHttpClient(httpClientStub);
         service.publish("message");
@@ -57,7 +56,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void successfulPublishToASingleRoomReturnsTrue() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", null, "#room1");
         HttpClientStub httpClientStub = new HttpClientStub();
         httpClientStub.setHttpStatus(HttpStatus.SC_OK);
         service.setHttpClient(httpClientStub);
@@ -66,7 +65,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void successfulPublishToMultipleRoomsReturnsTrue() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1,#room2,#room3");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", null, "#room1,#room2,#room3");
         HttpClientStub httpClientStub = new HttpClientStub();
         httpClientStub.setHttpStatus(HttpStatus.SC_OK);
         service.setHttpClient(httpClientStub);
@@ -75,7 +74,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void failedPublishToASingleRoomReturnsFalse() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", null, "#room1");
         HttpClientStub httpClientStub = new HttpClientStub();
         httpClientStub.setHttpStatus(HttpStatus.SC_NOT_FOUND);
         service.setHttpClient(httpClientStub);
@@ -84,7 +83,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void singleFailedPublishToMultipleRoomsReturnsFalse() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1,#room2,#room3");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", null, "#room1,#room2,#room3");
         HttpClientStub httpClientStub = new HttpClientStub();
         httpClientStub.setFailAlternateResponses(true);
         httpClientStub.setHttpStatus(HttpStatus.SC_OK);
@@ -94,7 +93,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void publishToEmptyRoomReturnsTrue() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", null, "");
         HttpClientStub httpClientStub = new HttpClientStub();
         httpClientStub.setHttpStatus(HttpStatus.SC_OK);
         service.setHttpClient(httpClientStub);

--- a/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepIntegrationTest.java
+++ b/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepIntegrationTest.java
@@ -21,6 +21,7 @@ public class SlackSendStepIntegrationTest {
         step1.setColor("good");
         step1.setChannel("#channel");
         step1.setToken("token");
+        step1.setTokenCredentialId("tokenCredentialId");
         step1.setTeamDomain("teamDomain");
         step1.setFailOnError(true);
 
@@ -32,7 +33,7 @@ public class SlackSendStepIntegrationTest {
     public void test_global_config_override() throws Exception {
         WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "workflow");
         //just define message
-        job.setDefinition(new CpsFlowDefinition("slackSend(message: 'message', teamDomain: 'teamDomain', token: 'token', channel: '#channel', color: 'good');", true));
+        job.setDefinition(new CpsFlowDefinition("slackSend(message: 'message', teamDomain: 'teamDomain', token: 'token', tokenCredentialId: 'tokenCredentialId', channel: '#channel', color: 'good');", true));
         WorkflowRun run = jenkinsRule.assertBuildStatusSuccess(job.scheduleBuild2(0).get());
         //everything should come from step configuration
         jenkinsRule.assertLogContains(Messages.SlackSendStepConfig(false, false, false, false), run);
@@ -42,7 +43,7 @@ public class SlackSendStepIntegrationTest {
     public void test_fail_on_error() throws Exception {
         WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "workflow");
         //just define message
-        job.setDefinition(new CpsFlowDefinition("slackSend(message: 'message', teamDomain: 'teamDomain', token: 'token', channel: '#channel', color: 'good', failOnError: true);", true));
+        job.setDefinition(new CpsFlowDefinition("slackSend(message: 'message', teamDomain: 'teamDomain', token: 'token', tokenCredentialId: 'tokenCredentialId', channel: '#channel', color: 'good', failOnError: true);", true));
         WorkflowRun run = jenkinsRule.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0).get());
         //everything should come from step configuration
         jenkinsRule.assertLogContains(Messages.NotificationFailed(), run);

--- a/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepTest.java
+++ b/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.*;
 import static org.powermock.api.mockito.PowerMockito.spy;
 
 /**
- * Traditional Unit tests, allows testing null Jenkins,getInstance()
+ * Traditional Unit tests, allows testing null Jenkins.getInstance()
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Jenkins.class,SlackSendStep.class})
@@ -55,6 +55,7 @@ public class SlackSendStepTest {
         SlackSendStep.SlackSendStepExecution stepExecution = spy(new SlackSendStep.SlackSendStepExecution());
         SlackSendStep slackSendStep = new SlackSendStep("message");
         slackSendStep.setToken("token");
+        slackSendStep.setTokenCredentialId("tokenCredentialId");
         slackSendStep.setTeamDomain("teamDomain");
         slackSendStep.setChannel("channel");
         slackSendStep.setColor("good");
@@ -70,11 +71,11 @@ public class SlackSendStepTest {
         when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
         doNothing().when(printStreamMock).println();
 
-        when(stepExecution.getSlackService(anyString(), anyString(), anyString())).thenReturn(slackServiceMock);
+        when(stepExecution.getSlackService(anyString(), anyString(), anyString(), anyString())).thenReturn(slackServiceMock);
         when(slackServiceMock.publish(anyString(), anyString())).thenReturn(true);
 
         stepExecution.run();
-        verify(stepExecution, times(1)).getSlackService("teamDomain", "token", "channel");
+        verify(stepExecution, times(1)).getSlackService("teamDomain", "token", "tokenCredentialId", "channel");
         verify(slackServiceMock, times(1)).publish("message", "good");
         assertFalse(stepExecution.step.isFailOnError());
     }
@@ -91,18 +92,20 @@ public class SlackSendStepTest {
 
         when(slackDescMock.getTeamDomain()).thenReturn("globalTeamDomain");
         when(slackDescMock.getToken()).thenReturn("globalToken");
+        when(slackDescMock.getTokenCredentialId()).thenReturn("globalTokenCredentialId");
         when(slackDescMock.getRoom()).thenReturn("globalChannel");
 
         when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
         doNothing().when(printStreamMock).println();
 
-        when(stepExecution.getSlackService(anyString(), anyString(), anyString())).thenReturn(slackServiceMock);
+        when(stepExecution.getSlackService(anyString(), anyString(), anyString(), anyString())).thenReturn(slackServiceMock);
 
         stepExecution.run();
-        verify(stepExecution, times(1)).getSlackService("globalTeamDomain", "globalToken", "globalChannel");
+        verify(stepExecution, times(1)).getSlackService("globalTeamDomain", "globalToken", "globalTokenCredentialId", "globalChannel");
         verify(slackServiceMock, times(1)).publish("message", "");
         assertNull(stepExecution.step.getTeamDomain());
         assertNull(stepExecution.step.getToken());
+        assertNull(stepExecution.step.getTokenCredentialId());
         assertNull(stepExecution.step.getChannel());
         assertNull(stepExecution.step.getColor());
     }
@@ -122,7 +125,7 @@ public class SlackSendStepTest {
         when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
         doNothing().when(printStreamMock).println();
 
-        when(stepExecution.getSlackService(anyString(), anyString(), anyString())).thenReturn(slackServiceMock);
+        when(stepExecution.getSlackService(anyString(), anyString(), anyString(), anyString())).thenReturn(slackServiceMock);
 
         stepExecution.run();
         verify(slackServiceMock, times(1)).publish("message", "");


### PR DESCRIPTION
Most importantly, this is a fix for [JENKINS-35503](https://issues.jenkins-ci.org/browse/JENKINS-35503). Based on work done in PR #208 
Example of integrating with xmlns:c="/lib/credentials" c:select for selecting credentials. Feel free to merge or not.

Create credential set:
![image](https://cloud.githubusercontent.com/assets/983526/17971588/6c26dfa0-6aa9-11e6-808c-3e139446e013.png)

Apply to Slack configuration:
![image](https://cloud.githubusercontent.com/assets/983526/17971458/ec296bf6-6aa8-11e6-8d19-06d9f1c9d611.png)