### PR TITLE
Proxy server additions

### DIFF
--- a/src/main/java/jenkins/plugins/slack/SlackNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/SlackNotifier.java
@@ -35,6 +35,7 @@ public class SlackNotifier extends Notifier {
     private String authToken;
     private String buildServerUrl;
     private String room;
+    private String proxyServerUrl;
     private String sendAs;
     private boolean startNotification;
     private boolean notifySuccess;
@@ -60,6 +61,10 @@ public class SlackNotifier extends Notifier {
 
     public String getRoom() {
         return room;
+    }
+    
+    public String getProxyServerUrl() {
+        return proxyServerUrl;
     }
 
     public String getAuthToken() {
@@ -129,7 +134,7 @@ public class SlackNotifier extends Notifier {
     }
 
     @DataBoundConstructor
-    public SlackNotifier(final String teamDomain, final String authToken, final String room, final String buildServerUrl,
+    public SlackNotifier(final String teamDomain, final String authToken, final String room, final String buildServerUrl, final String proxyServerUrl,
                          final String sendAs, final boolean startNotification, final boolean notifyAborted, final boolean notifyFailure,
                          final boolean notifyNotBuilt, final boolean notifySuccess, final boolean notifyUnstable, final boolean notifyBackToNormal,
                          final boolean notifyRepeatedFailure, final boolean includeTestSummary, CommitInfoChoice commitInfoChoice,
@@ -139,6 +144,7 @@ public class SlackNotifier extends Notifier {
         this.authToken = authToken;
         this.buildServerUrl = buildServerUrl;
         this.room = room;
+        this.proxyServerUrl = proxyServerUrl;
         this.sendAs = sendAs;
         this.startNotification = startNotification;
         this.notifyAborted = notifyAborted;
@@ -171,6 +177,10 @@ public class SlackNotifier extends Notifier {
         if (StringUtils.isEmpty(room)) {
             room = getDescriptor().getRoom();
         }
+        String proxyServerUrl = this.proxyServerUrl;
+        if (StringUtils.isEmpty(proxyServerUrl)) {
+            proxyServerUrl = getDescriptor().getProxyServerUrl();
+        }
 
         EnvVars env = null;
         try {
@@ -183,7 +193,7 @@ public class SlackNotifier extends Notifier {
         authToken = env.expand(authToken);
         room = env.expand(room);
 
-        return new StandardSlackService(teamDomain, authToken, room);
+        return new StandardSlackService(teamDomain, authToken, room, proxyServerUrl);
     }
 
     @Override
@@ -212,6 +222,7 @@ public class SlackNotifier extends Notifier {
         private String token;
         private String room;
         private String buildServerUrl;
+        private String proxyServerUrl;
         private String sendAs;
 
         public static final CommitInfoChoice[] COMMIT_INFO_CHOICES = CommitInfoChoice.values();
@@ -230,6 +241,10 @@ public class SlackNotifier extends Notifier {
 
         public String getRoom() {
             return room;
+        }
+        
+        public String getProxyServerUrl() {
+            return proxyServerUrl;
         }
 
         public String getBuildServerUrl() {
@@ -255,6 +270,7 @@ public class SlackNotifier extends Notifier {
             String teamDomain = sr.getParameter("slackTeamDomain");
             String token = sr.getParameter("slackToken");
             String room = sr.getParameter("slackRoom");
+            String proxyServerUrl = sr.getParameter("proxyServerUrl");
             boolean startNotification = "true".equals(sr.getParameter("slackStartNotification"));
             boolean notifySuccess = "true".equals(sr.getParameter("slackNotifySuccess"));
             boolean notifyAborted = "true".equals(sr.getParameter("slackNotifyAborted"));
@@ -267,7 +283,7 @@ public class SlackNotifier extends Notifier {
             CommitInfoChoice commitInfoChoice = CommitInfoChoice.forDisplayName(sr.getParameter("slackCommitInfoChoice"));
             boolean includeCustomMessage = "on".equals(sr.getParameter("includeCustomMessage"));
             String customMessage = sr.getParameter("customMessage");
-            return new SlackNotifier(teamDomain, token, room, buildServerUrl, sendAs, startNotification, notifyAborted,
+            return new SlackNotifier(teamDomain, token, room, buildServerUrl, proxyServerUrl, sendAs, startNotification, notifyAborted,
                     notifyFailure, notifyNotBuilt, notifySuccess, notifyUnstable, notifyBackToNormal, notifyRepeatedFailure,
                     includeTestSummary, commitInfoChoice, includeCustomMessage, customMessage);
         }
@@ -278,6 +294,7 @@ public class SlackNotifier extends Notifier {
             token = sr.getParameter("slackToken");
             room = sr.getParameter("slackRoom");
             buildServerUrl = sr.getParameter("slackBuildServerUrl");
+            proxyServerUrl = sr.getParameter("slackProxyServerUrl");
             sendAs = sr.getParameter("slackSendAs");
             if(buildServerUrl == null || buildServerUrl == "") {
                 JenkinsLocationConfiguration jenkinsConfig = new JenkinsLocationConfiguration();
@@ -290,8 +307,8 @@ public class SlackNotifier extends Notifier {
             return super.configure(sr, formData);
         }
 
-        SlackService getSlackService(final String teamDomain, final String authToken, final String room) {
-            return new StandardSlackService(teamDomain, authToken, room);
+        SlackService getSlackService(final String teamDomain, final String authToken, final String room, final String proxyServerUrl) {
+            return new StandardSlackService(teamDomain, authToken, room, proxyServerUrl);
         }
 
         @Override
@@ -302,7 +319,8 @@ public class SlackNotifier extends Notifier {
         public FormValidation doTestConnection(@QueryParameter("slackTeamDomain") final String teamDomain,
                                                @QueryParameter("slackToken") final String authToken,
                                                @QueryParameter("slackRoom") final String room,
-                                               @QueryParameter("slackBuildServerUrl") final String buildServerUrl) throws FormException {
+                                               @QueryParameter("slackBuildServerUrl") final String buildServerUrl,
+                                               @QueryParameter("slackProxyServerUrl") final String proxyServerUrl) throws FormException {
             try {
                 String targetDomain = teamDomain;
                 if (StringUtils.isEmpty(targetDomain)) {
@@ -320,7 +338,11 @@ public class SlackNotifier extends Notifier {
                 if (StringUtils.isEmpty(targetBuildServerUrl)) {
                     targetBuildServerUrl = this.buildServerUrl;
                 }
-                SlackService testSlackService = getSlackService(targetDomain, targetToken, targetRoom);
+                String targetProxyServerUrl = proxyServerUrl;
+                if (StringUtils.isEmpty(targetProxyServerUrl)) {
+                    targetProxyServerUrl = this.proxyServerUrl;
+                }
+                SlackService testSlackService = getSlackService(targetDomain, targetToken, targetRoom, targetProxyServerUrl);
                 String message = "Slack/Jenkins plugin: you're all set on " + targetBuildServerUrl;
                 boolean success = testSlackService.publish(message, "good");
                 return success ? FormValidation.ok("Success") : FormValidation.error("Failure");

--- a/src/main/java/jenkins/plugins/slack/workflow/SlackSendStep.java
+++ b/src/main/java/jenkins/plugins/slack/workflow/SlackSendStep.java
@@ -29,6 +29,7 @@ public class SlackSendStep extends AbstractStepImpl {
     private String token;
     private String channel;
     private String teamDomain;
+    private String proxyServerUri;
     private boolean failOnError;
 
 
@@ -71,6 +72,15 @@ public class SlackSendStep extends AbstractStepImpl {
     @DataBoundSetter
     public void setTeamDomain(String teamDomain) {
         this.teamDomain = Util.fixEmpty(teamDomain);
+    }
+
+    @DataBoundSetter
+    public void setProxyServerUri(String proxyServerUri) {
+        this.proxyServerUri = Util.fixEmpty(proxyServerUri);
+    }
+
+    public String getProxyServerUri() {
+        return proxyServerUri;
     }
 
     public boolean isFailOnError() {
@@ -132,11 +142,12 @@ public class SlackSendStep extends AbstractStepImpl {
             String token = step.token != null ? step.token : slackDesc.getToken();
             String channel = step.channel != null ? step.channel : slackDesc.getRoom();
             String color = step.color != null ? step.color : "";
+            String proxy = step.proxyServerUri != null ? step.proxyServerUri : slackDesc.getProxyServerUrl();
 
             //placing in console log to simplify testing of retrieving values from global config or from step field; also used for tests
             listener.getLogger().println(Messages.SlackSendStepConfig(step.teamDomain == null, step.token == null, step.channel == null, step.color == null));
 
-            SlackService slackService = getSlackService(team, token, channel);
+            SlackService slackService = getSlackService(team, token, channel, proxy);
             boolean publishSuccess = slackService.publish(step.message, color);
             if (!publishSuccess && step.failOnError) {
                 throw new AbortException(Messages.NotificationFailed());
@@ -147,8 +158,8 @@ public class SlackSendStep extends AbstractStepImpl {
         }
 
         //streamline unit testing
-        SlackService getSlackService(String team, String token, String channel) {
-            return new StandardSlackService(team, token, channel);
+        SlackService getSlackService(String team, String token, String channel, String proxyServerUri) {
+            return new StandardSlackService(team, token, channel, proxyServerUri);
         }
 
     }

--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/global.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/global.jelly
@@ -24,8 +24,11 @@
     <f:entry title="Build Server URL" help="${rootURL}/plugin/slack/help-globalConfig-slackBuildServerUrl.html">
         <f:textbox field="buildServerUrl" name="slackBuildServerUrl" value="${descriptor.getBuildServerUrl()}" />
     </f:entry>
+    <f:entry title="Proxy Server URL" help="${rootURL}/plugin/slack/help-globalConfig-slackBuildServerUrl.html">
+        <f:textbox field="proxyServerUrl" name="slackProxyServerUrl" value="${descriptor.getProxyServerUrl()}" />
+    </f:entry>
     <f:validateButton
         title="${%Test Connection}" progress="${%Testing...}"
-        method="testConnection" with="slackTeamDomain,slackToken,slackRoom,slackBuildServerUrl" />
+        method="testConnection" with="slackTeamDomain,slackToken,slackRoom,slackBuildServerUrl, slackProxyServerUrl" />
   </f:section>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/slack/workflow/SlackSendStep/config.jelly
+++ b/src/main/resources/jenkins/plugins/slack/workflow/SlackSendStep/config.jelly
@@ -17,6 +17,9 @@
         <f:entry field="teamDomain" title="Team Domain">
             <f:textbox />
         </f:entry>
+        <f:entry field="proxyServerUrl" title="Proxy Server">
+            <f:textbox />
+        </f:entry>
         <f:entry field="failOnError">
             <f:checkbox title="Fail On Error" default="false"/>
         </f:entry>

--- a/src/main/resources/jenkins/plugins/slack/workflow/SlackSendStep/help-proxyServerUri.html
+++ b/src/main/resources/jenkins/plugins/slack/workflow/SlackSendStep/help-proxyServerUri.html
@@ -1,0 +1,6 @@
+<div>
+    Allows overriding the Slack Plugin Proxy Server specified in the global configuration.<br>
+    Acceptable formats are: proxy-server.example.com | proxy-server.example.com:9323.<br>
+    If no port is specified this will default to use port 8080.<br>
+    <code>slackSend channel: "#channel-name", proxyServerUri: "proxy.server.com:4382", message: "Build Started: ${env.JOB_NAME} ${env.BUILD_NUMBER}"</code>
+</div>

--- a/src/test/java/jenkins/plugins/slack/SlackNotifierStub.java
+++ b/src/test/java/jenkins/plugins/slack/SlackNotifierStub.java
@@ -2,12 +2,12 @@ package jenkins.plugins.slack;
 
 public class SlackNotifierStub extends SlackNotifier {
 
-    public SlackNotifierStub(String teamDomain, String authToken, String room, String buildServerUrl,
+    public SlackNotifierStub(String teamDomain, String authToken, String room, String buildServerUrl, String proxyServerUrl,
                              String sendAs, boolean startNotification, boolean notifyAborted, boolean notifyFailure,
                              boolean notifyNotBuilt, boolean notifySuccess, boolean notifyUnstable, boolean notifyBackToNormal,
                              boolean notifyRepeatedFailure, boolean includeTestSummary, CommitInfoChoice commitInfoChoice,
                              boolean includeCustomMessage, String customMessage) {
-        super(teamDomain, authToken, room, buildServerUrl, sendAs, startNotification, notifyAborted, notifyFailure,
+        super(teamDomain, authToken, room, buildServerUrl, proxyServerUrl, sendAs, startNotification, notifyAborted, notifyFailure,
                 notifyNotBuilt, notifySuccess, notifyUnstable, notifyBackToNormal, notifyRepeatedFailure,
                 includeTestSummary, commitInfoChoice, includeCustomMessage, customMessage);
     }
@@ -21,7 +21,7 @@ public class SlackNotifierStub extends SlackNotifier {
         }
 
         @Override
-        SlackService getSlackService(final String teamDomain, final String authToken, final String room) {
+        SlackService getSlackService(final String teamDomain, final String authToken, final String room, final String proxyServerUrl) {
             return slackService;
         }
 

--- a/src/test/java/jenkins/plugins/slack/SlackNotifierTest.java
+++ b/src/test/java/jenkins/plugins/slack/SlackNotifierTest.java
@@ -47,7 +47,7 @@ public class SlackNotifierTest extends TestCase {
         }
         descriptor.setSlackService(slackServiceStub);
         try {
-            FormValidation result = descriptor.doTestConnection("teamDomain", "authToken", "room", "buildServerUrl");
+            FormValidation result = descriptor.doTestConnection("teamDomain", "authToken", "room", "buildServerUrl", "proxyServerUrl");
             assertEquals(result.kind, expectedResult);
         } catch (Descriptor.FormException e) {
             e.printStackTrace();

--- a/src/test/java/jenkins/plugins/slack/StandardSlackServiceStub.java
+++ b/src/test/java/jenkins/plugins/slack/StandardSlackServiceStub.java
@@ -4,8 +4,8 @@ public class StandardSlackServiceStub extends StandardSlackService {
 
     private HttpClientStub httpClientStub;
 
-    public StandardSlackServiceStub(String teamDomain, String token, String roomId) {
-        super(teamDomain, token, roomId);
+    public StandardSlackServiceStub(String teamDomain, String token, String roomId, String proxyServerUrl) {
+        super(teamDomain, token, roomId, proxyServerUrl);
     }
 
     @Override

--- a/src/test/java/jenkins/plugins/slack/StandardSlackServiceTest.java
+++ b/src/test/java/jenkins/plugins/slack/StandardSlackServiceTest.java
@@ -14,7 +14,7 @@ public class StandardSlackServiceTest {
      */
     @Test
     public void publishWithBadHostShouldNotRethrowExceptions() {
-        StandardSlackService service = new StandardSlackService("foo", "token", "#general");
+        StandardSlackService service = new StandardSlackService("foo", "token", "#general", "");
         service.setHost("hostvaluethatwillcausepublishtofail");
         service.publish("message");
     }
@@ -24,7 +24,7 @@ public class StandardSlackServiceTest {
      */
     @Test
     public void invalidTeamDomainShouldFail() {
-        StandardSlackService service = new StandardSlackService("my", "token", "#general");
+        StandardSlackService service = new StandardSlackService("my", "token", "#general", "");
         service.publish("message");
     }
 
@@ -33,13 +33,13 @@ public class StandardSlackServiceTest {
      */
     @Test
     public void invalidTokenShouldFail() {
-        StandardSlackService service = new StandardSlackService("tinyspeck", "token", "#general");
+        StandardSlackService service = new StandardSlackService("tinyspeck", "token", "#general", "");
         service.publish("message");
     }
 
     @Test
     public void publishToASingleRoomSendsASingleMessage() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1", "");
         HttpClientStub httpClientStub = new HttpClientStub();
         service.setHttpClient(httpClientStub);
         service.publish("message");
@@ -48,7 +48,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void publishToMultipleRoomsSendsAMessageToEveryRoom() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1,#room2,#room3");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1,#room2,#room3", "");
         HttpClientStub httpClientStub = new HttpClientStub();
         service.setHttpClient(httpClientStub);
         service.publish("message");
@@ -57,7 +57,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void successfulPublishToASingleRoomReturnsTrue() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1", "");
         HttpClientStub httpClientStub = new HttpClientStub();
         httpClientStub.setHttpStatus(HttpStatus.SC_OK);
         service.setHttpClient(httpClientStub);
@@ -66,7 +66,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void successfulPublishToMultipleRoomsReturnsTrue() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1,#room2,#room3");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1,#room2,#room3", "");
         HttpClientStub httpClientStub = new HttpClientStub();
         httpClientStub.setHttpStatus(HttpStatus.SC_OK);
         service.setHttpClient(httpClientStub);
@@ -75,7 +75,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void failedPublishToASingleRoomReturnsFalse() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1", "");
         HttpClientStub httpClientStub = new HttpClientStub();
         httpClientStub.setHttpStatus(HttpStatus.SC_NOT_FOUND);
         service.setHttpClient(httpClientStub);
@@ -84,7 +84,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void singleFailedPublishToMultipleRoomsReturnsFalse() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1,#room2,#room3");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1,#room2,#room3", "");
         HttpClientStub httpClientStub = new HttpClientStub();
         httpClientStub.setFailAlternateResponses(true);
         httpClientStub.setHttpStatus(HttpStatus.SC_OK);
@@ -94,7 +94,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void publishToEmptyRoomReturnsTrue() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "", "");
         HttpClientStub httpClientStub = new HttpClientStub();
         httpClientStub.setHttpStatus(HttpStatus.SC_OK);
         service.setHttpClient(httpClientStub);

--- a/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepTest.java
+++ b/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepTest.java
@@ -58,6 +58,7 @@ public class SlackSendStepTest {
         slackSendStep.setTeamDomain("teamDomain");
         slackSendStep.setChannel("channel");
         slackSendStep.setColor("good");
+        slackSendStep.setProxyServerUri("proxy");
         stepExecution.step = slackSendStep;
 
         when(Jenkins.getInstance()).thenReturn(jenkins);
@@ -70,11 +71,11 @@ public class SlackSendStepTest {
         when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
         doNothing().when(printStreamMock).println();
 
-        when(stepExecution.getSlackService(anyString(), anyString(), anyString())).thenReturn(slackServiceMock);
+        when(stepExecution.getSlackService(anyString(), anyString(), anyString(), anyString())).thenReturn(slackServiceMock);
         when(slackServiceMock.publish(anyString(), anyString())).thenReturn(true);
 
         stepExecution.run();
-        verify(stepExecution, times(1)).getSlackService("teamDomain", "token", "channel");
+        verify(stepExecution, times(1)).getSlackService("teamDomain", "token", "channel", "proxy");
         verify(slackServiceMock, times(1)).publish("message", "good");
         assertFalse(stepExecution.step.isFailOnError());
     }
@@ -92,14 +93,15 @@ public class SlackSendStepTest {
         when(slackDescMock.getTeamDomain()).thenReturn("globalTeamDomain");
         when(slackDescMock.getToken()).thenReturn("globalToken");
         when(slackDescMock.getRoom()).thenReturn("globalChannel");
+        when(slackDescMock.getProxyServerUrl()).thenReturn("globalProxy");
 
         when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
         doNothing().when(printStreamMock).println();
 
-        when(stepExecution.getSlackService(anyString(), anyString(), anyString())).thenReturn(slackServiceMock);
+        when(stepExecution.getSlackService(anyString(), anyString(), anyString(), anyString())).thenReturn(slackServiceMock);
 
         stepExecution.run();
-        verify(stepExecution, times(1)).getSlackService("globalTeamDomain", "globalToken", "globalChannel");
+        verify(stepExecution, times(1)).getSlackService("globalTeamDomain", "globalToken", "globalChannel", "globalProxy");
         verify(slackServiceMock, times(1)).publish("message", "");
         assertNull(stepExecution.step.getTeamDomain());
         assertNull(stepExecution.step.getToken());
@@ -122,7 +124,7 @@ public class SlackSendStepTest {
         when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
         doNothing().when(printStreamMock).println();
 
-        when(stepExecution.getSlackService(anyString(), anyString(), anyString())).thenReturn(slackServiceMock);
+        when(stepExecution.getSlackService(anyString(), anyString(), anyString(), anyString())).thenReturn(slackServiceMock);
 
         stepExecution.run();
         verify(slackServiceMock, times(1)).publish("message", "");


### PR DESCRIPTION
PR 171 has additions to support proxy servers for sending slack notifications however this did not allow us to use it if we had a non-standard proxy server port (in my case 3128 instead of 8080), these additions allow any proxy server port as well as use of the slackSend workflow step.
