### PR TITLE
Implement bot-user support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ Create a new ***Secret text*** credential:
 Select that credential as the value for the ***Integration Token Credential ID*** field:
 ![image](https://cloud.githubusercontent.com/assets/983526/17971458/ec296bf6-6aa8-11e6-8d19-06d9f1c9d611.png)
 
+
+#### Bot user option
+This plugin supports sending notifications via bot users. You can enable bot user support from both 
+global and project configurations. If the notification will be sent to a user via direct message, 
+default integration sends it via @slackbot, you can use this option if you want to send messages via a bot user.
+You need to provide credentials of the bot user for integration token credentials to use this feature. 
+
 #### Jenkins Pipeline Support
 
 Includes [Jenkins Pipeline](https://github.com/jenkinsci/workflow-plugin) support as of version 2.0:

--- a/src/main/java/jenkins/plugins/slack/StandardSlackService.java
+++ b/src/main/java/jenkins/plugins/slack/StandardSlackService.java
@@ -1,19 +1,19 @@
 package jenkins.plugins.slack;
 
+import hudson.ProxyConfiguration;
+import jenkins.model.Jenkins;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.PostMethod;
-
-import org.json.JSONObject;
-import org.json.JSONArray;
-
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import jenkins.model.Jenkins;
-import hudson.ProxyConfiguration;
 import org.apache.commons.httpclient.UsernamePasswordCredentials;
 import org.apache.commons.httpclient.auth.AuthScope;
+import org.apache.commons.httpclient.methods.PostMethod;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class StandardSlackService implements SlackService {
 
@@ -22,12 +22,14 @@ public class StandardSlackService implements SlackService {
     private String host = "slack.com";
     private String teamDomain;
     private String token;
+    private boolean botUser;
     private String[] roomIds;
 
-    public StandardSlackService(String teamDomain, String token, String roomId) {
+    public StandardSlackService(String teamDomain, String token, boolean botUser, String roomId) {
         super();
         this.teamDomain = teamDomain;
         this.token = token;
+        this.botUser = botUser;
         this.roomIds = roomId.split("[,; ]+");
     }
 
@@ -38,45 +40,63 @@ public class StandardSlackService implements SlackService {
     public boolean publish(String message, String color) {
         boolean result = true;
         for (String roomId : roomIds) {
-            String url = "https://" + teamDomain + "." + host + "/services/hooks/jenkins-ci?token=" + token;
-            logger.info("Posting: to " + roomId + " on " + teamDomain + " using " + url +": " + message + " " + color);
-            HttpClient client = getHttpClient();
-            PostMethod post = new PostMethod(url);
-            JSONObject json = new JSONObject();
+            //prepare attachments first
+            JSONObject field = new JSONObject();
+            field.put("short", false);
+            field.put("value", message);
 
-            try {
-                JSONObject field = new JSONObject();
-                field.put("short", false);
-                field.put("value", message);
+            JSONArray fields = new JSONArray();
+            fields.put(field);
 
-                JSONArray fields = new JSONArray();
-                fields.put(field);
+            JSONObject attachment = new JSONObject();
+            attachment.put("fallback", message);
+            attachment.put("color", color);
+            attachment.put("fields", fields);
+            JSONArray mrkdwn = new JSONArray();
+            mrkdwn.put("pretext");
+            mrkdwn.put("text");
+            mrkdwn.put("fields");
+            attachment.put("mrkdwn_in", mrkdwn);
+            JSONArray attachments = new JSONArray();
+            attachments.put(attachment);
 
-                JSONObject attachment = new JSONObject();
-                attachment.put("fallback", message);
-                attachment.put("color", color);
-                attachment.put("fields", fields);
-                JSONArray mrkdwn = new JSONArray();
-                mrkdwn.put("pretext");
-                mrkdwn.put("text");
-                mrkdwn.put("fields");
-                attachment.put("mrkdwn_in", mrkdwn);
-                JSONArray attachments = new JSONArray();
-                attachments.put(attachment);
+            PostMethod post;
+            String url;
+            //prepare post methods for both requests types
+            if (!botUser) {
+                url = "https://" + teamDomain + "." + host + "/services/hooks/jenkins-ci?token=" + token;
+                post = new PostMethod(url);
+                JSONObject json = new JSONObject();
 
                 json.put("channel", roomId);
                 json.put("attachments", attachments);
                 json.put("link_names", "1");
 
                 post.addParameter("payload", json.toString());
-                post.getParams().setContentCharset("UTF-8");
+
+            } else {
+                url = "https://slack.com/api/chat.postMessage?token=" + token +
+                        "&channel=" + roomId +
+                        "&link_names=1" +
+                        "&as_user=true";
+                try {
+                    url += "&attachments=" + URLEncoder.encode(attachments.toString(), "utf-8");
+                } catch (UnsupportedEncodingException e) {
+                    logger.log(Level.ALL, "Error while encoding attachments: " + e.getMessage());
+                }
+                post = new PostMethod(url);
+            }
+            logger.info("Posting: to " + roomId + " on " + teamDomain + " using " + url + ": " + message + " " + color);
+            HttpClient client = getHttpClient();
+            post.getParams().setContentCharset("UTF-8");
+
+            try {
                 int responseCode = client.executeMethod(post);
                 String response = post.getResponseBodyAsString();
-                if(responseCode != HttpStatus.SC_OK) {
+                if (responseCode != HttpStatus.SC_OK) {
                     logger.log(Level.WARNING, "Slack post may have failed. Response: " + response);
                     result = false;
-                }
-                else {
+                } else {
                     logger.info("Posting succeeded");
                 }
             } catch (Exception e) {
@@ -104,7 +124,7 @@ public class StandardSlackService implements SlackService {
                     // and
                     // http://svn.apache.org/viewvc/httpcomponents/oac.hc3x/trunk/src/examples/BasicAuthenticationExample.java?view=markup
                     client.getState().setProxyCredentials(AuthScope.ANY,
-                        new UsernamePasswordCredentials(username, password));
+                            new UsernamePasswordCredentials(username, password));
                 }
             }
         }

--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
@@ -59,6 +59,10 @@
             <f:textbox name="slackToken" value="${instance.getAuthToken()}"/>
         </f:entry>
 
+        <f:entry title="Is Bot User?" help="${rootURL}/plugin/slack/help-projectConfig-slackToken.html">
+            <f:checkbox name="slackBotUser" value="true" checked="${instance.getBotUser()}"/>
+        </f:entry>
+
         <f:entry title="Project Channel" help="${rootURL}/plugin/slack/help-projectConfig-slackRoom.html">
             <f:textbox name="slackRoom" value="${instance.getRoom()}"/>
         </f:entry>

--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
@@ -63,7 +63,7 @@
             <c:select value="${instance.getAuthTokenCredentialId()}"/>
         </f:entry>
 
-        <f:entry title="Is Bot User?" help="/plugin/slack/help-projectConfig-slackToken.html">
+        <f:entry title="Is Bot User?" help="/plugin/slack/help-projectConfig-botUser.html">
             <f:checkbox name="slackBotUser" value="true" checked="${instance.getBotUser()}"/>
         </f:entry>
 

--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/global.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/global.jelly
@@ -21,7 +21,7 @@
     <f:entry title="Integration Token Credential ID" field="tokenCredentialId" name="tokenCredentialId" help="/plugin/slack/help-globalConfig-tokenCredentialId.html">
         <c:select/>
     </f:entry>
-    <f:entry title="Is Bot User?" help="/plugin/slack/help-globalConfig-slackToken.html">
+    <f:entry title="Is Bot User?" help="/plugin/slack/help-globalConfig-botUser.html">
         <f:checkbox field="botUser" name="slackBotUser" value="true" checked="${descriptor.getBotUser()}" />
     </f:entry>
     <f:entry title="Channel" help="/plugin/slack/help-globalConfig-slackRoom.html">

--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/global.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/global.jelly
@@ -18,6 +18,9 @@
     <f:entry title="Integration Token" help="${rootURL}/plugin/slack/help-globalConfig-slackToken.html">
         <f:textbox field="token" name="slackToken" value="${descriptor.getToken()}" />
     </f:entry>
+    <f:entry title="Is Bot User?" help="${rootURL}/plugin/slack/help-globalConfig-slackToken.html">
+        <f:checkbox field="botUser" name="slackBotUser" value="true" checked="${descriptor.getBotUser()}" />
+    </f:entry>
     <f:entry title="Channel" help="${rootURL}/plugin/slack/help-globalConfig-slackRoom.html">
         <f:textbox field="room" name="slackRoom" value="${descriptor.getRoom()}" />
     </f:entry>

--- a/src/main/resources/jenkins/plugins/slack/workflow/SlackSendStep/config.jelly
+++ b/src/main/resources/jenkins/plugins/slack/workflow/SlackSendStep/config.jelly
@@ -14,6 +14,9 @@
         <f:entry field="token" title="Integration Token">
             <f:textbox />
         </f:entry>
+        <f:entry field="botUser" title="Is Bot User?">
+            <f:checkbox />
+        </f:entry>
         <f:entry field="teamDomain" title="Team Domain">
             <f:textbox />
         </f:entry>

--- a/src/main/webapp/help-globalConfig-botUser.html
+++ b/src/main/webapp/help-globalConfig-botUser.html
@@ -1,0 +1,4 @@
+<div>
+    <p>Bot user option indicates the token belongs to a bot user in Slack.</p>
+    <p>If the notification will be sent to a user via direct message, the default integration sends it via @slackbot, use this option if you want to send messages via a bot user.</p>
+</div>

--- a/src/main/webapp/help-projectConfig-botUser.html
+++ b/src/main/webapp/help-projectConfig-botUser.html
@@ -1,0 +1,4 @@
+<div>
+    <p>Bot user option indicates the token belongs to a bot user in Slack.</p>
+    <p>If the notification will be sent to a user via direct message, the default integration sends it via @slackbot, use this option if you want to send messages via a bot user.</p>
+</div>

--- a/src/test/java/jenkins/plugins/slack/SlackNotifierStub.java
+++ b/src/test/java/jenkins/plugins/slack/SlackNotifierStub.java
@@ -2,12 +2,12 @@ package jenkins.plugins.slack;
 
 public class SlackNotifierStub extends SlackNotifier {
 
-    public SlackNotifierStub(String teamDomain, String authToken, String room, String buildServerUrl,
+    public SlackNotifierStub(String teamDomain, String authToken, boolean botUser, String room, String buildServerUrl,
                              String sendAs, boolean startNotification, boolean notifyAborted, boolean notifyFailure,
                              boolean notifyNotBuilt, boolean notifySuccess, boolean notifyUnstable, boolean notifyBackToNormal,
                              boolean notifyRepeatedFailure, boolean includeTestSummary, CommitInfoChoice commitInfoChoice,
                              boolean includeCustomMessage, String customMessage) {
-        super(teamDomain, authToken, room, buildServerUrl, sendAs, startNotification, notifyAborted, notifyFailure,
+        super(teamDomain, authToken, botUser, room, buildServerUrl, sendAs, startNotification, notifyAborted, notifyFailure,
                 notifyNotBuilt, notifySuccess, notifyUnstable, notifyBackToNormal, notifyRepeatedFailure,
                 includeTestSummary, commitInfoChoice, includeCustomMessage, customMessage);
     }
@@ -21,7 +21,7 @@ public class SlackNotifierStub extends SlackNotifier {
         }
 
         @Override
-        SlackService getSlackService(final String teamDomain, final String authToken, final String room) {
+        SlackService getSlackService(final String teamDomain, final String authToken, final boolean botUser, final String room) {
             return slackService;
         }
 

--- a/src/test/java/jenkins/plugins/slack/SlackNotifierTest.java
+++ b/src/test/java/jenkins/plugins/slack/SlackNotifierTest.java
@@ -47,7 +47,7 @@ public class SlackNotifierTest extends TestCase {
         }
         descriptor.setSlackService(slackServiceStub);
         try {
-            FormValidation result = descriptor.doTestConnection("teamDomain", "authToken", "room", "buildServerUrl");
+            FormValidation result = descriptor.doTestConnection("teamDomain", "authToken", false, "room", "buildServerUrl");
             assertEquals(result.kind, expectedResult);
         } catch (Descriptor.FormException e) {
             e.printStackTrace();

--- a/src/test/java/jenkins/plugins/slack/StandardSlackServiceStub.java
+++ b/src/test/java/jenkins/plugins/slack/StandardSlackServiceStub.java
@@ -4,8 +4,8 @@ public class StandardSlackServiceStub extends StandardSlackService {
 
     private HttpClientStub httpClientStub;
 
-    public StandardSlackServiceStub(String teamDomain, String token, String roomId) {
-        super(teamDomain, token, roomId);
+    public StandardSlackServiceStub(String teamDomain, String token, boolean botUser, String roomId) {
+        super(teamDomain, token, botUser, roomId);
     }
 
     @Override

--- a/src/test/java/jenkins/plugins/slack/StandardSlackServiceTest.java
+++ b/src/test/java/jenkins/plugins/slack/StandardSlackServiceTest.java
@@ -14,7 +14,7 @@ public class StandardSlackServiceTest {
      */
     @Test
     public void publishWithBadHostShouldNotRethrowExceptions() {
-        StandardSlackService service = new StandardSlackService("foo", "token", "#general");
+        StandardSlackService service = new StandardSlackService("foo", "token", false, "#general");
         service.setHost("hostvaluethatwillcausepublishtofail");
         service.publish("message");
     }
@@ -24,7 +24,7 @@ public class StandardSlackServiceTest {
      */
     @Test
     public void invalidTeamDomainShouldFail() {
-        StandardSlackService service = new StandardSlackService("my", "token", "#general");
+        StandardSlackService service = new StandardSlackService("my", "token", false, "#general");
         service.publish("message");
     }
 
@@ -33,13 +33,13 @@ public class StandardSlackServiceTest {
      */
     @Test
     public void invalidTokenShouldFail() {
-        StandardSlackService service = new StandardSlackService("tinyspeck", "token", "#general");
+        StandardSlackService service = new StandardSlackService("tinyspeck", "token", false, "#general");
         service.publish("message");
     }
 
     @Test
     public void publishToASingleRoomSendsASingleMessage() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", false, "#room1");
         HttpClientStub httpClientStub = new HttpClientStub();
         service.setHttpClient(httpClientStub);
         service.publish("message");
@@ -48,7 +48,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void publishToMultipleRoomsSendsAMessageToEveryRoom() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1,#room2,#room3");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", false, "#room1,#room2,#room3");
         HttpClientStub httpClientStub = new HttpClientStub();
         service.setHttpClient(httpClientStub);
         service.publish("message");
@@ -57,7 +57,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void successfulPublishToASingleRoomReturnsTrue() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", false, "#room1");
         HttpClientStub httpClientStub = new HttpClientStub();
         httpClientStub.setHttpStatus(HttpStatus.SC_OK);
         service.setHttpClient(httpClientStub);
@@ -66,7 +66,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void successfulPublishToMultipleRoomsReturnsTrue() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1,#room2,#room3");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", false, "#room1,#room2,#room3");
         HttpClientStub httpClientStub = new HttpClientStub();
         httpClientStub.setHttpStatus(HttpStatus.SC_OK);
         service.setHttpClient(httpClientStub);
@@ -75,7 +75,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void failedPublishToASingleRoomReturnsFalse() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", false, "#room1");
         HttpClientStub httpClientStub = new HttpClientStub();
         httpClientStub.setHttpStatus(HttpStatus.SC_NOT_FOUND);
         service.setHttpClient(httpClientStub);
@@ -84,7 +84,7 @@ public class StandardSlackServiceTest {
 
     @Test
     public void singleFailedPublishToMultipleRoomsReturnsFalse() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "#room1,#room2,#room3");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", false, "#room1,#room2,#room3");
         HttpClientStub httpClientStub = new HttpClientStub();
         httpClientStub.setFailAlternateResponses(true);
         httpClientStub.setHttpStatus(HttpStatus.SC_OK);
@@ -94,7 +94,16 @@ public class StandardSlackServiceTest {
 
     @Test
     public void publishToEmptyRoomReturnsTrue() {
-        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", "");
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", false, "");
+        HttpClientStub httpClientStub = new HttpClientStub();
+        httpClientStub.setHttpStatus(HttpStatus.SC_OK);
+        service.setHttpClient(httpClientStub);
+        assertTrue(service.publish("message"));
+    }
+
+    @Test
+    public void sendAsBotUserReturnsTrue() {
+        StandardSlackServiceStub service = new StandardSlackServiceStub("domain", "token", true, "#room1");
         HttpClientStub httpClientStub = new HttpClientStub();
         httpClientStub.setHttpStatus(HttpStatus.SC_OK);
         service.setHttpClient(httpClientStub);

--- a/src/test/java/jenkins/plugins/slack/config/BackwordsCompatible_1_8_SlackNotifierTest.java
+++ b/src/test/java/jenkins/plugins/slack/config/BackwordsCompatible_1_8_SlackNotifierTest.java
@@ -42,6 +42,7 @@ public class BackwordsCompatible_1_8_SlackNotifierTest {
 
         assertEquals("jenkins-slack-plugin", notifier.getTeamDomain());
         assertEquals("auth-token-for-test", notifier.getAuthToken());
+        assertEquals(false, notifier.getBotUser());
         assertEquals("http://localhost:8080/", notifier.getBuildServerUrl());
         assertEquals("#slack-plugin-testing", notifier.getRoom());
 
@@ -69,6 +70,7 @@ public class BackwordsCompatible_1_8_SlackNotifierTest {
 
         assertEquals("jenkins-slack-plugin", notifier.getTeamDomain());
         assertEquals("auth-token-for-test", notifier.getAuthToken());
+        assertEquals(false, notifier.getBotUser());
         assertEquals("http://localhost:8080/", notifier.getBuildServerUrl());
         assertEquals("#slack-plugin-testing", notifier.getRoom());
 
@@ -96,6 +98,7 @@ public class BackwordsCompatible_1_8_SlackNotifierTest {
 
         assertEquals("", notifier.getTeamDomain());
         assertEquals("", notifier.getAuthToken());
+        assertEquals(false, notifier.getBotUser());
         assertEquals(j.getURL().toString(), notifier.getBuildServerUrl());
         assertEquals("", notifier.getRoom());
 
@@ -151,6 +154,7 @@ public class BackwordsCompatible_1_8_SlackNotifierTest {
 
         assertEquals("", notifier.getTeamDomain());
         assertEquals("", notifier.getAuthToken());
+        assertEquals(false, notifier.getBotUser());
         assertEquals(j.getURL().toString(), notifier.getBuildServerUrl());
         assertEquals("", notifier.getRoom());
 

--- a/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepTest.java
+++ b/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepTest.java
@@ -55,6 +55,7 @@ public class SlackSendStepTest {
         SlackSendStep.SlackSendStepExecution stepExecution = spy(new SlackSendStep.SlackSendStepExecution());
         SlackSendStep slackSendStep = new SlackSendStep("message");
         slackSendStep.setToken("token");
+        slackSendStep.setBotUser(false);
         slackSendStep.setTeamDomain("teamDomain");
         slackSendStep.setChannel("channel");
         slackSendStep.setColor("good");
@@ -65,16 +66,16 @@ public class SlackSendStepTest {
         stepExecution.listener = taskListenerMock;
 
         when(slackDescMock.getToken()).thenReturn("differentToken");
-
+        when(slackDescMock.getBotUser()).thenReturn(true);
 
         when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
         doNothing().when(printStreamMock).println();
 
-        when(stepExecution.getSlackService(anyString(), anyString(), anyString())).thenReturn(slackServiceMock);
+        when(stepExecution.getSlackService(anyString(), anyString(),  anyBoolean(), anyString())).thenReturn(slackServiceMock);
         when(slackServiceMock.publish(anyString(), anyString())).thenReturn(true);
 
         stepExecution.run();
-        verify(stepExecution, times(1)).getSlackService("teamDomain", "token", "channel");
+        verify(stepExecution, times(1)).getSlackService("teamDomain", "token", false, "channel");
         verify(slackServiceMock, times(1)).publish("message", "good");
         assertFalse(stepExecution.step.isFailOnError());
     }
@@ -91,15 +92,16 @@ public class SlackSendStepTest {
 
         when(slackDescMock.getTeamDomain()).thenReturn("globalTeamDomain");
         when(slackDescMock.getToken()).thenReturn("globalToken");
+        when(slackDescMock.getBotUser()).thenReturn(false);
         when(slackDescMock.getRoom()).thenReturn("globalChannel");
 
         when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
         doNothing().when(printStreamMock).println();
 
-        when(stepExecution.getSlackService(anyString(), anyString(), anyString())).thenReturn(slackServiceMock);
+        when(stepExecution.getSlackService(anyString(), anyString(), anyBoolean(), anyString())).thenReturn(slackServiceMock);
 
         stepExecution.run();
-        verify(stepExecution, times(1)).getSlackService("globalTeamDomain", "globalToken", "globalChannel");
+        verify(stepExecution, times(1)).getSlackService("globalTeamDomain", "globalToken", false, "globalChannel");
         verify(slackServiceMock, times(1)).publish("message", "");
         assertNull(stepExecution.step.getTeamDomain());
         assertNull(stepExecution.step.getToken());
@@ -122,7 +124,7 @@ public class SlackSendStepTest {
         when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
         doNothing().when(printStreamMock).println();
 
-        when(stepExecution.getSlackService(anyString(), anyString(), anyString())).thenReturn(slackServiceMock);
+        when(stepExecution.getSlackService(anyString(), anyString(), anyBoolean(), anyString())).thenReturn(slackServiceMock);
 
         stepExecution.run();
         verify(slackServiceMock, times(1)).publish("message", "");

--- a/src/test/resources/jenkins/plugins/slack/config/BackwordsCompatible_1_8_SlackNotifierTest/testGlobalSettingsNotOverridden/jobs/Test_Slack_Plugin/config.xml
+++ b/src/test/resources/jenkins/plugins/slack/config/BackwordsCompatible_1_8_SlackNotifierTest/testGlobalSettingsNotOverridden/jobs/Test_Slack_Plugin/config.xml
@@ -38,6 +38,7 @@
     <jenkins.plugins.slack.SlackNotifier plugin="slack@1.8.1-SNAPSHOT">
       <teamDomain></teamDomain>
       <authToken></authToken>
+      <botUser></botUser>
       <buildServerUrl></buildServerUrl>
       <room></room>
     </jenkins.plugins.slack.SlackNotifier>


### PR DESCRIPTION
I have added a checkbox which indicates given token belongs to a bot user or not.

But why?

Recently, I have figured out that if I put @username to channel parameter, the plugin sends a direct message via @slackbot. But I didn't want @slackbot to send me a dm, a bot (preferably named jenkins-bot) should send me a dm. So here it is.
- In global config and advanced job config, there is a checkbox named "Is Bot User?" (false by default). 
- If this checkbox is checked, the plugin will send a post request to https://slack.com/api/chat.postMessage .
- Also, I added all parameters to request URI if "bot-user" is true, leaving the original case as it is, because sending parameters in JSON body didn't work for chat.postMessage endpoint, I assume there is a special case for "/services/hooks/jenkins-ci". 
- Lastly, there are a few string equals improvements that I couldn't resist.
