### PR TITLE
Run our migration process before any other

### DIFF
--- a/src/main/java/jenkins/plugins/slack/SlackNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/SlackNotifier.java
@@ -479,7 +479,7 @@ public class SlackNotifier extends Notifier {
 
     }
 
-    @Extension public static final class Migrator extends ItemListener {
+    @Extension(ordinal = 100) public static final class Migrator extends ItemListener {
         @SuppressWarnings("deprecation")
         @Override
         public void onLoaded() {


### PR DESCRIPTION
In order to fix the compatibility issue with EnvInject plugin,
we need to ensure that our migration process runs before the one
in the EnvInject plugin. Extensions are sorted in the descending order
of the ordinal, so setting ordinal = 100 will make our extension first
in the list returned by `ItemListener.all()`

This ordering approach is fragile and usually discouraged, but this
should work as the ordinal of the EnvInject migration extension is 0
(which is the default value).

This patch fixes #257 and makes the migration process proposed in https://github.com/jenkinsci/slack-plugin/issues/188#issuecomment-200862166 obsolete.

@reviewbybees esp @kmadel 