### PR TITLE
moved message to 'text' instead of 'fields' to resolve truncated message issue

### DIFF
--- a/src/main/java/jenkins/plugins/slack/StandardSlackService.java
+++ b/src/main/java/jenkins/plugins/slack/StandardSlackService.java
@@ -58,17 +58,11 @@ public class StandardSlackService implements SlackService {
         boolean result = true;
         for (String roomId : roomIds) {
             //prepare attachments first
-            JSONObject field = new JSONObject();
-            field.put("short", false);
-            field.put("value", message);
-
-            JSONArray fields = new JSONArray();
-            fields.put(field);
-
             JSONObject attachment = new JSONObject();
+            attachment.put("text", message);
             attachment.put("fallback", message);
             attachment.put("color", color);
-            attachment.put("fields", fields);
+            
             JSONArray mrkdwn = new JSONArray();
             mrkdwn.put("pretext");
             mrkdwn.put("text");


### PR DESCRIPTION
**Change:** moved message to 'text' instead of 'fields' to resolve truncated message issue
Reason: As per issue filed on slack api, the "value" of fields has max length of around 4k chars which leads to text truncated post that and since, there is no much usage of huge text, there is no "show more" wrapping link too so the message gets missed. the same problem is with "pretext" as well.

To solve that, changed to "text" which shows wrapped content with "show more" link

**Why would someone need large text to send** 
My Use case: I have my automated tests running and let say there are failures, I have parsed way more huge logs of more than 10k lines and created this text having responsible 's committer name with a short summary for catching all's attention to look at their specific service so that my attachment is not ignored. Yes I could just give link for devs to open and see all details there but thats where the problem is, no one really like to open a link unless it looks like his/her own issue. in some cases, if there are more failures, obviously my text gets bigger and so I need all of them to come posted on slack (its ok to click on "show more" than not getting the content at all)

**Note:** if this PR sounds good, I'll raise 1 more  by next week which will serve the benefits of having "fields" for which originally the plugin was written i.e. there will be 1 more field say "footer" where I will use "fields" to display fixed content upfront (without need to click on "show more")

- [x] **Tests**: Yes, Tests Passes