### PR TITLE
Add display failed tests option to slack notifications on job configuration 

### DIFF
--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -379,9 +379,10 @@ public class ActiveNotifier implements FineGrainedNotifier {
                     .getAction(AbstractTestResultAction.class);
             if (action != null) {
                 int failed = action.getFailCount();
-                message.append("\n").append(failed).append(" failed Tests:\n");
+                message.append("\n").append(failed).append(" Failed Tests:\n");
                 for(TestResult result : action.getFailedTests()) {
-                    message.append("\t").append(result.getName()).append("\n");
+                    message.append("\t").append(result.getName()).append(" after ")
+                            .append(result.getDurationString()).append("\n");
                 }
             }
             return this;

--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
@@ -36,7 +36,7 @@
         <f:entry title="Include Test Summary">
             <f:checkbox name="includeTestSummary" value="true" checked="${instance.includeTestSummary()}"/>
         </f:entry>
-        <f:entry title="Include failed Tests">
+        <f:entry title="Include Failed Tests">
             <f:checkbox name="includeFailedTests" value="true" checked="${instance.includeFailedTests()}"/>
         </f:entry>
 


### PR DESCRIPTION
I've added an option as "Include Failed Tests" to slack notifications on job configuration screen to display failed tests.

PR#166 also adds the failed tests but I think there should be an option for user to choose on configurations. Also there was a conflict on that PR and it was very old, so I've opened this one.
<img width="580" alt="screen shot 2016-12-23 at 01 40 35" src="https://cloud.githubusercontent.com/assets/2565698/21442735/e86e0948-c8b0-11e6-9296-7b79800cbe68.png">
