### PR TITLE
Regression notification implemented.

### DIFF
--- a/src/main/java/jenkins/plugins/slack/SlackListener.java
+++ b/src/main/java/jenkins/plugins/slack/SlackListener.java
@@ -42,8 +42,8 @@ public class SlackListener extends RunListener<AbstractBuild> {
 
     @Override
     public void onFinalized(AbstractBuild r) {
-        // getNotifier(r.getProject()).finalized(r);
-        // super.onFinalized(r);
+         getNotifier(r.getProject(), null).finalized(r);
+         super.onFinalized(r);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/jenkins/plugins/slack/SlackNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/SlackNotifier.java
@@ -53,6 +53,7 @@ public class SlackNotifier extends Notifier {
     private boolean notifyAborted;
     private boolean notifyNotBuilt;
     private boolean notifyUnstable;
+    private boolean notifyRegression;
     private boolean notifyFailure;
     private boolean notifyBackToNormal;
     private boolean notifyRepeatedFailure;
@@ -153,6 +154,10 @@ public class SlackNotifier extends Notifier {
         return notifyUnstable;
     }
 
+    public boolean getNotifyRegression() {
+        return notifyRegression;
+    }
+
     public boolean getNotifyBackToNormal() {
         return notifyBackToNormal;
     }
@@ -213,6 +218,11 @@ public class SlackNotifier extends Notifier {
     }
 
     @DataBoundSetter
+    public void setNotifyRegression(boolean notifyRegression) {
+        this.notifyRegression = notifyRegression;
+    }
+
+    @DataBoundSetter
     public void setNotifyBackToNormal(boolean notifyBackToNormal) {
         this.notifyBackToNormal = notifyBackToNormal;
     }
@@ -244,7 +254,7 @@ public class SlackNotifier extends Notifier {
 
     public SlackNotifier(final String baseUrl, final String teamDomain, final String authToken, final boolean botUser, final String room, final String authTokenCredentialId,
                          final String sendAs, final boolean startNotification, final boolean notifyAborted, final boolean notifyFailure,
-                         final boolean notifyNotBuilt, final boolean notifySuccess, final boolean notifyUnstable, final boolean notifyBackToNormal,
+                         final boolean notifyNotBuilt, final boolean notifySuccess, final boolean notifyUnstable, final boolean notifyRegression, final boolean notifyBackToNormal,
                          final boolean notifyRepeatedFailure, final boolean includeTestSummary, final boolean includeFailedTests,
                          CommitInfoChoice commitInfoChoice, boolean includeCustomMessage, String customMessage) {
         super();
@@ -264,6 +274,7 @@ public class SlackNotifier extends Notifier {
         this.notifyNotBuilt = notifyNotBuilt;
         this.notifySuccess = notifySuccess;
         this.notifyUnstable = notifyUnstable;
+        this.notifyRegression = notifyRegression;
         this.notifyBackToNormal = notifyBackToNormal;
         this.notifyRepeatedFailure = notifyRepeatedFailure;
         this.includeTestSummary = includeTestSummary;
@@ -423,6 +434,7 @@ public class SlackNotifier extends Notifier {
             boolean notifyAborted = "true".equals(sr.getParameter("slackNotifyAborted"));
             boolean notifyNotBuilt = "true".equals(sr.getParameter("slackNotifyNotBuilt"));
             boolean notifyUnstable = "true".equals(sr.getParameter("slackNotifyUnstable"));
+            boolean notifyRegression = "true".equals(sr.getParameter("slackNotifyRegression"));
             boolean notifyFailure = "true".equals(sr.getParameter("slackNotifyFailure"));
             boolean notifyBackToNormal = "true".equals(sr.getParameter("slackNotifyBackToNormal"));
             boolean notifyRepeatedFailure = "true".equals(sr.getParameter("slackNotifyRepeatedFailure"));
@@ -432,7 +444,7 @@ public class SlackNotifier extends Notifier {
             boolean includeCustomMessage = "on".equals(sr.getParameter("includeCustomMessage"));
             String customMessage = sr.getParameter("customMessage");
             return new SlackNotifier(baseUrl, teamDomain, token, botUser, room, tokenCredentialId, sendAs, startNotification, notifyAborted,
-                    notifyFailure, notifyNotBuilt, notifySuccess, notifyUnstable, notifyBackToNormal, notifyRepeatedFailure,
+                    notifyFailure, notifyNotBuilt, notifySuccess, notifyUnstable, notifyRegression, notifyBackToNormal, notifyRepeatedFailure,
                     includeTestSummary, includeFailedTests, commitInfoChoice, includeCustomMessage, customMessage);
         }
 
@@ -515,6 +527,7 @@ public class SlackNotifier extends Notifier {
         private boolean notifyAborted;
         private boolean notifyNotBuilt;
         private boolean notifyUnstable;
+        private boolean notifyRegression;
         private boolean notifyFailure;
         private boolean notifyBackToNormal;
         private boolean notifyRepeatedFailure;
@@ -534,6 +547,7 @@ public class SlackNotifier extends Notifier {
                                 boolean notifyNotBuilt,
                                 boolean notifySuccess,
                                 boolean notifyUnstable,
+                                boolean notifyRegression,
                                 boolean notifyBackToNormal,
                                 boolean notifyRepeatedFailure,
                                 boolean includeTestSummary,
@@ -550,6 +564,7 @@ public class SlackNotifier extends Notifier {
             this.notifyNotBuilt = notifyNotBuilt;
             this.notifySuccess = notifySuccess;
             this.notifyUnstable = notifyUnstable;
+            this.notifyRegression = notifyRegression;
             this.notifyBackToNormal = notifyBackToNormal;
             this.notifyRepeatedFailure = notifyRepeatedFailure;
             this.includeTestSummary = includeTestSummary;
@@ -616,6 +631,11 @@ public class SlackNotifier extends Notifier {
         @Exported
         public boolean getNotifyUnstable() {
             return notifyUnstable;
+        }
+
+        @Exported
+        public boolean getNotifyRegression() {
+            return notifyRegression;
         }
 
         @Exported

--- a/src/main/java/jenkins/plugins/slack/config/AbstractProjectConfigMigrator.java
+++ b/src/main/java/jenkins/plugins/slack/config/AbstractProjectConfigMigrator.java
@@ -79,6 +79,7 @@ public class AbstractProjectConfigMigrator {
         slackNotifier.setNotifyNotBuilt(slackJobProperty.getNotifyNotBuilt());
         slackNotifier.setNotifySuccess(slackJobProperty.getNotifySuccess());
         slackNotifier.setNotifyUnstable(slackJobProperty.getNotifyUnstable());
+        slackNotifier.setNotifyRegression(slackJobProperty.getNotifyRegression());
         slackNotifier.setNotifyBackToNormal(slackJobProperty.getNotifyBackToNormal());
         slackNotifier.setNotifyRepeatedFailure(slackJobProperty.getNotifyRepeatedFailure());
 

--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
@@ -24,6 +24,11 @@
         <f:checkbox name="slackNotifyUnstable" value="true" checked="${instance.getNotifyUnstable()}"/>
     </f:entry>
 
+    <f:entry title="Notify Regression">
+        <f:checkbox name="slackNotifyRegression" value="true" checked="${instance.getNotifyRegression()}"/>
+    </f:entry>
+
+
     <f:entry title="Notify Back To Normal">
         <f:checkbox name="slackNotifyBackToNormal" value="true" checked="${instance.getNotifyBackToNormal()}"/>
     </f:entry>

--- a/src/test/java/jenkins/plugins/slack/SlackNotifierStub.java
+++ b/src/test/java/jenkins/plugins/slack/SlackNotifierStub.java
@@ -4,11 +4,11 @@ public class SlackNotifierStub extends SlackNotifier {
 
     public SlackNotifierStub(String baseUrl, String teamDomain, String authToken, boolean botUser, String room, String authTokenCredentialId,
                              String sendAs, boolean startNotification, boolean notifyAborted, boolean notifyFailure,
-                             boolean notifyNotBuilt, boolean notifySuccess, boolean notifyUnstable, boolean notifyBackToNormal,
+                             boolean notifyNotBuilt, boolean notifySuccess, boolean notifyUnstable, boolean notifyRegression, boolean notifyBackToNormal,
                              boolean notifyRepeatedFailure, boolean includeTestSummary, boolean includeFailedTests, 
                              CommitInfoChoice commitInfoChoice, boolean includeCustomMessage, String customMessage) {
         super(baseUrl, teamDomain, authToken, botUser, room, authTokenCredentialId, sendAs, startNotification, notifyAborted, notifyFailure,
-                notifyNotBuilt, notifySuccess, notifyUnstable, notifyBackToNormal, notifyRepeatedFailure,
+                notifyNotBuilt, notifySuccess, notifyUnstable, notifyRegression, notifyBackToNormal, notifyRepeatedFailure,
                 includeTestSummary, includeFailedTests, commitInfoChoice, includeCustomMessage, customMessage);
     }
 

--- a/src/test/java/jenkins/plugins/slack/config/BackwordsCompatible_1_8_SlackNotifierTest.java
+++ b/src/test/java/jenkins/plugins/slack/config/BackwordsCompatible_1_8_SlackNotifierTest.java
@@ -50,6 +50,7 @@ public class BackwordsCompatible_1_8_SlackNotifierTest {
         assertFalse(notifier.getNotifyAborted());
         assertFalse(notifier.getNotifyNotBuilt());
         assertFalse(notifier.getNotifyUnstable());
+        assertFalse(notifier.getNotifyRegression());
         assertTrue(notifier.getNotifyFailure());
         assertFalse(notifier.getNotifyBackToNormal());
         assertFalse(notifier.getNotifyRepeatedFailure());
@@ -77,6 +78,7 @@ public class BackwordsCompatible_1_8_SlackNotifierTest {
         assertFalse(notifier.getNotifyAborted());
         assertFalse(notifier.getNotifyNotBuilt());
         assertFalse(notifier.getNotifyUnstable());
+        assertFalse(notifier.getNotifyRegression());
         assertTrue(notifier.getNotifyFailure());
         assertFalse(notifier.getNotifyBackToNormal());
         assertFalse(notifier.getNotifyRepeatedFailure());
@@ -104,6 +106,7 @@ public class BackwordsCompatible_1_8_SlackNotifierTest {
         assertFalse(notifier.getNotifyAborted());
         assertFalse(notifier.getNotifyNotBuilt());
         assertFalse(notifier.getNotifyUnstable());
+        assertFalse(notifier.getNotifyRegression());
         assertTrue(notifier.getNotifyFailure());
         assertFalse(notifier.getNotifyBackToNormal());
         assertFalse(notifier.getNotifyRepeatedFailure());
@@ -159,6 +162,7 @@ public class BackwordsCompatible_1_8_SlackNotifierTest {
         assertTrue(notifier.getNotifyAborted());
         assertTrue(notifier.getNotifyNotBuilt());
         assertTrue(notifier.getNotifyUnstable());
+        assertTrue(notifier.getNotifyRegression());
         assertTrue(notifier.getNotifyFailure());
         assertTrue(notifier.getNotifyBackToNormal());
         assertTrue(notifier.getNotifyRepeatedFailure());

--- a/src/test/resources/jenkins/plugins/slack/config/BackwordsCompatible_1_8_SlackNotifierTest/testBasicMigration/jobs/Test_Slack_Plugin/config.xml
+++ b/src/test/resources/jenkins/plugins/slack/config/BackwordsCompatible_1_8_SlackNotifierTest/testBasicMigration/jobs/Test_Slack_Plugin/config.xml
@@ -13,6 +13,7 @@
       <notifyAborted>false</notifyAborted>
       <notifyNotBuilt>false</notifyNotBuilt>
       <notifyUnstable>false</notifyUnstable>
+      <notifyRegression>false</notifyRegression>
       <notifyFailure>true</notifyFailure>
       <notifyBackToNormal>false</notifyBackToNormal>
       <notifyRepeatedFailure>false</notifyRepeatedFailure>

--- a/src/test/resources/jenkins/plugins/slack/config/BackwordsCompatible_1_8_SlackNotifierTest/testGlobalSettingsNotOverridden/jobs/Test_Slack_Plugin/config.xml
+++ b/src/test/resources/jenkins/plugins/slack/config/BackwordsCompatible_1_8_SlackNotifierTest/testGlobalSettingsNotOverridden/jobs/Test_Slack_Plugin/config.xml
@@ -13,6 +13,7 @@
       <notifyAborted>false</notifyAborted>
       <notifyNotBuilt>false</notifyNotBuilt>
       <notifyUnstable>false</notifyUnstable>
+      <notifyRegration>false</notifyRegration>
       <notifyFailure>true</notifyFailure>
       <notifyBackToNormal>false</notifyBackToNormal>
       <notifyRepeatedFailure>false</notifyRepeatedFailure>

--- a/src/test/resources/jenkins/plugins/slack/config/BackwordsCompatible_1_8_SlackNotifierTest/testGlobalSettingsOverriden/jobs/Test_Slack_Plugin/config.xml
+++ b/src/test/resources/jenkins/plugins/slack/config/BackwordsCompatible_1_8_SlackNotifierTest/testGlobalSettingsOverriden/jobs/Test_Slack_Plugin/config.xml
@@ -13,6 +13,7 @@
       <notifyAborted>false</notifyAborted>
       <notifyNotBuilt>false</notifyNotBuilt>
       <notifyUnstable>false</notifyUnstable>
+      <notifyRegression>false</notifyRegression>
       <notifyFailure>true</notifyFailure>
       <notifyBackToNormal>false</notifyBackToNormal>
       <notifyRepeatedFailure>false</notifyRepeatedFailure>

--- a/src/test/resources/jenkins/plugins/slack/config/BackwordsCompatible_1_8_SlackNotifierTest/testMigrationOfSomeJobs/jobs/Test_02/config.xml
+++ b/src/test/resources/jenkins/plugins/slack/config/BackwordsCompatible_1_8_SlackNotifierTest/testMigrationOfSomeJobs/jobs/Test_02/config.xml
@@ -13,6 +13,7 @@
       <notifyAborted>true</notifyAborted>
       <notifyNotBuilt>true</notifyNotBuilt>
       <notifyUnstable>true</notifyUnstable>
+      <notifyRegression>true</notifyRegression>
       <notifyFailure>true</notifyFailure>
       <notifyBackToNormal>true</notifyBackToNormal>
       <notifyRepeatedFailure>true</notifyRepeatedFailure>

--- a/src/test/resources/jenkins/plugins/slack/config/BackwordsCompatible_1_8_SlackNotifierTest/testMigrationWithNoNotifier/jobs/Test_01/config.xml
+++ b/src/test/resources/jenkins/plugins/slack/config/BackwordsCompatible_1_8_SlackNotifierTest/testMigrationWithNoNotifier/jobs/Test_01/config.xml
@@ -13,6 +13,7 @@
       <notifyAborted>false</notifyAborted>
       <notifyNotBuilt>false</notifyNotBuilt>
       <notifyUnstable>false</notifyUnstable>
+      <notifyRegression>false</notifyRegression>
       <notifyFailure>false</notifyFailure>
       <notifyBackToNormal>false</notifyBackToNormal>
       <notifyRepeatedFailure>false</notifyRepeatedFailure>


### PR DESCRIPTION
Notification generated for following cases:
- If number of failed tests increased. (Even when previous build was red).
- If the failed tests are different than previous build (Even when the number of failed tests are same as last build).

Will not notify for
- For failure that are same as previous build.

In short, will notify if the current build is worst than the previous build.