### PR TITLE
Append N lines from end of console log

### DIFF
--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -258,6 +258,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
         message.appendStatusMessage();
         message.appendDuration();
         message.appendOpenLink();
+        message.appendLog();
         if (includeTestSummary) {
             message.appendTestSummary();
         }
@@ -386,6 +387,35 @@ public class ActiveNotifier implements FineGrainedNotifier {
         public MessageBuilder appendOpenLink() {
             String url = DisplayURLProvider.get().getRunURL(build);
             message.append(" (<").append(url).append("|Open>)");
+            return this;
+        }
+
+        public MessageBuilder appendLog() {
+            List<String> lines;
+            try {
+                lines = build.getLog(Integer.MAX_VALUE);
+            } catch (IOException e) {
+                e.printStackTrace();
+                //Just print the stack trace and return
+                return this;
+            }
+            int maxLines;
+            try {
+                maxLines = Integer.parseInt(notifier.getNumberOfLogLines());
+            } catch (NumberFormatException e) {
+                //Ignore no integer values
+                maxLines = 0;
+            }
+
+            int startIndex = lines.size() - maxLines;
+
+            if (startIndex < 0) {
+                startIndex = 0;
+            }
+
+            for (int i = startIndex; i < lines.size(); ++i) {
+                message.append("\n").append(lines.get(i));
+            }
             return this;
         }
 

--- a/src/main/java/jenkins/plugins/slack/SlackNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/SlackNotifier.java
@@ -62,6 +62,7 @@ public class SlackNotifier extends Notifier {
     private CommitInfoChoice commitInfoChoice;
     private boolean includeCustomMessage;
     private String customMessage;
+    private String numberOfLogLines;
 
     @Override
     public DescriptorImpl getDescriptor() {
@@ -182,6 +183,9 @@ public class SlackNotifier extends Notifier {
         return customMessage;
     }
 
+    public String getNumberOfLogLines() { return numberOfLogLines; }
+
+
     @DataBoundSetter
     public void setStartNotification(boolean startNotification) {
         this.startNotification = startNotification;
@@ -256,7 +260,7 @@ public class SlackNotifier extends Notifier {
                          final String sendAs, final boolean startNotification, final boolean notifyAborted, final boolean notifyFailure,
                          final boolean notifyNotBuilt, final boolean notifySuccess, final boolean notifyUnstable, final boolean notifyRegression, final boolean notifyBackToNormal,
                          final boolean notifyRepeatedFailure, final boolean includeTestSummary, final boolean includeFailedTests,
-                         CommitInfoChoice commitInfoChoice, boolean includeCustomMessage, String customMessage) {
+                         CommitInfoChoice commitInfoChoice, boolean includeCustomMessage, String customMessage, String numberOfLogLines) {
         super();
         this.baseUrl = baseUrl;
         if(this.baseUrl != null && !this.baseUrl.isEmpty() && !this.baseUrl.endsWith("/")) {
@@ -282,6 +286,7 @@ public class SlackNotifier extends Notifier {
         this.commitInfoChoice = commitInfoChoice;
         this.includeCustomMessage = includeCustomMessage;
         this.customMessage = customMessage;
+        this.numberOfLogLines = numberOfLogLines;
     }
 
     public BuildStepMonitor getRequiredMonitorService() {
@@ -443,9 +448,10 @@ public class SlackNotifier extends Notifier {
             CommitInfoChoice commitInfoChoice = CommitInfoChoice.forDisplayName(sr.getParameter("slackCommitInfoChoice"));
             boolean includeCustomMessage = "on".equals(sr.getParameter("includeCustomMessage"));
             String customMessage = sr.getParameter("customMessage");
+            String numberOfLogLines = sr.getParameter("numberOfLogLines");
             return new SlackNotifier(baseUrl, teamDomain, token, botUser, room, tokenCredentialId, sendAs, startNotification, notifyAborted,
                     notifyFailure, notifyNotBuilt, notifySuccess, notifyUnstable, notifyRegression, notifyBackToNormal, notifyRepeatedFailure,
-                    includeTestSummary, includeFailedTests, commitInfoChoice, includeCustomMessage, customMessage);
+                    includeTestSummary, includeFailedTests, commitInfoChoice, includeCustomMessage, customMessage, numberOfLogLines);
         }
 
         @Override
@@ -535,6 +541,7 @@ public class SlackNotifier extends Notifier {
         private boolean showCommitList;
         private boolean includeCustomMessage;
         private String customMessage;
+        private String numberOfLogLines;
 
         @DataBoundConstructor
         public SlackJobProperty(String teamDomain,
@@ -553,7 +560,8 @@ public class SlackNotifier extends Notifier {
                                 boolean includeTestSummary,
                                 boolean showCommitList,
                                 boolean includeCustomMessage,
-                                String customMessage) {
+                                String customMessage,
+                                String numberOfLogLines) {
             this.teamDomain = teamDomain;
             this.token = token;
             this.botUser = botUser;
@@ -571,6 +579,7 @@ public class SlackNotifier extends Notifier {
             this.showCommitList = showCommitList;
             this.includeCustomMessage = includeCustomMessage;
             this.customMessage = customMessage;
+            this.numberOfLogLines = numberOfLogLines;
         }
 
         @Exported
@@ -663,6 +672,10 @@ public class SlackNotifier extends Notifier {
             return customMessage;
         }
 
+        @Exported
+        public String getNumberOfLogLines() {
+            return numberOfLogLines;
+        }
     }
 
     @Extension(ordinal = 100) public static final class Migrator extends ItemListener {

--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
@@ -33,6 +33,10 @@
         <f:checkbox name="slackNotifyBackToNormal" value="true" checked="${instance.getNotifyBackToNormal()}"/>
     </f:entry>
 
+    <f:entry title="Number of lines of log file to include">
+        <f:textbox name="numberOfLogLines" value="${instance.getNumberOfLogLines()}"/>
+    </f:entry>
+
     <f:advanced>
         <f:entry title="Notify Repeated Failure">
             <f:checkbox name="slackNotifyRepeatedFailure" value="true"

--- a/src/test/java/jenkins/plugins/slack/SlackNotifierStub.java
+++ b/src/test/java/jenkins/plugins/slack/SlackNotifierStub.java
@@ -6,10 +6,10 @@ public class SlackNotifierStub extends SlackNotifier {
                              String sendAs, boolean startNotification, boolean notifyAborted, boolean notifyFailure,
                              boolean notifyNotBuilt, boolean notifySuccess, boolean notifyUnstable, boolean notifyRegression, boolean notifyBackToNormal,
                              boolean notifyRepeatedFailure, boolean includeTestSummary, boolean includeFailedTests, 
-                             CommitInfoChoice commitInfoChoice, boolean includeCustomMessage, String customMessage) {
+                             CommitInfoChoice commitInfoChoice, boolean includeCustomMessage, String customMessage, String numberOfLogLines) {
         super(baseUrl, teamDomain, authToken, botUser, room, authTokenCredentialId, sendAs, startNotification, notifyAborted, notifyFailure,
                 notifyNotBuilt, notifySuccess, notifyUnstable, notifyRegression, notifyBackToNormal, notifyRepeatedFailure,
-                includeTestSummary, includeFailedTests, commitInfoChoice, includeCustomMessage, customMessage);
+                includeTestSummary, includeFailedTests, commitInfoChoice, includeCustomMessage, customMessage, numberOfLogLines);
     }
 
     public static class DescriptorImplStub extends SlackNotifier.DescriptorImpl {

--- a/src/test/java/jenkins/plugins/slack/webhook/WebhookEndpointTest.java
+++ b/src/test/java/jenkins/plugins/slack/webhook/WebhookEndpointTest.java
@@ -51,7 +51,7 @@ public class WebhookEndpointTest {
 
     private final String URL = "webook";
     private final String ENDPOINT = URL+"/";
-    private final String LONG_PROJECT_NAME = "¶12345678  90怒qwertyuioplkjhgfdsazxcvbnm~()-_=+7{},.\"'    5";
+    private final String LONG_PROJECT_NAME = "0123456780900qwertyuioplkjhgfdsazxcvbnm0";
 
     private List<NameValuePair> data;
 


### PR DESCRIPTION
This feature enables the user to be able to choose how many lines from the tail of the console log they want to be appended to the slack message.
Default value is 0.