### PR TITLE
Reduce verbosity for standard situation

### DIFF
--- a/src/main/java/jenkins/plugins/slack/config/AbstractProjectConfigMigrator.java
+++ b/src/main/java/jenkins/plugins/slack/config/AbstractProjectConfigMigrator.java
@@ -33,7 +33,7 @@ public class AbstractProjectConfigMigrator {
         final SlackJobProperty slackJobProperty = project.getProperty(SlackJobProperty.class);
 
         if (slackJobProperty == null) {
-            logger.info(String.format(
+            logger.finest(String.format(
                     "Configuration is already up to date for \"%s\", skipping migration",
                     project.getName()));
             return;

--- a/src/main/java/jenkins/plugins/slack/config/JobConfigMigrator.java
+++ b/src/main/java/jenkins/plugins/slack/config/JobConfigMigrator.java
@@ -32,7 +32,7 @@ public class JobConfigMigrator {
         final SlackJobProperty slackJobProperty = job.getProperty(SlackJobProperty.class);
 
         if (slackJobProperty == null) {
-            logger.info(String.format(
+            logger.finest(String.format(
                     "Configuration is already up to date for \"%s\", skipping migration",
                     job.getName()));
             return;


### PR DESCRIPTION
Hello !
Right now, I see thousands of logs like

```
2017-04-19 15:14:07.036-0500 [id=35]	INFO	j.p.slack.SlackNotifier$Migrator#onLoaded: Configuration is already up to date for "REDACTED", skipping migration
```

As this is a log that is expected each time once the migration has been applied, I think its verbosity should be set to lowest to avoid spamming log files and making actual issues harder to spot.

Thanks!

@reviewbybees 