### PR TITLE
Update help-projectConfig-slackBaseUrl.html

### DIFF
--- a/src/main/webapp/help-projectConfig-slackBaseUrl.html
+++ b/src/main/webapp/help-projectConfig-slackBaseUrl.html
@@ -1,5 +1,5 @@
 <div>
-	<p>Your Slack compatible Base URL. Example: https://chat.mycompany.com/hooks/</p>
+	<p>Your Slack-compatible-chat's (e.g. Mattermost or Rocket Chat) Base URL. Example: https://chat.mycompany.com/hooks/</p>
         <p>Bot-User is not supported with Base URL.<p>
 	<p>This overrides the global setting.</p>
 </div>


### PR DESCRIPTION
I think it is helpful to clearly explain that base URL is needed for slack-compatible-chats only. I only found this information after searching for _baseUrl_ in the whole repo and digging through the change log.

solves #328 