### PR TITLE
Fix token when set on steps

### DIFF
--- a/src/main/java/jenkins/plugins/slack/StandardSlackService.java
+++ b/src/main/java/jenkins/plugins/slack/StandardSlackService.java
@@ -156,7 +156,7 @@ public class StandardSlackService implements SlackService {
     }
 
     private String getTokenToUse() {
-        if (authTokenCredentialId != null && !authTokenCredentialId.isEmpty()) {
+        if (token == null && authTokenCredentialId != null && !authTokenCredentialId.isEmpty()) {
             StringCredentials credentials = lookupCredentials(authTokenCredentialId);
             if (credentials != null) {
                 logger.fine("Using Integration Token Credential ID.");


### PR DESCRIPTION
If a token is set on steps, use it instead of using tokenCredentialId