### PR TITLE
Fixes issue #218, that was prematurely closed.

### DIFF
--- a/src/main/java/jenkins/plugins/slack/webhook/WebhookEndpoint.java
+++ b/src/main/java/jenkins/plugins/slack/webhook/WebhookEndpoint.java
@@ -52,7 +52,7 @@ public class WebhookEndpoint implements UnprotectedRootAction {
         if (url == null || url.equals(""))
             return UUID.randomUUID().toString().replaceAll("-", "");
 
-        return "/"+url;
+        return url;
     }
 
     @RequirePOST


### PR DESCRIPTION
Removed unnecessary leading "/" from WebhookEndpoint#getUrlName.
Now it works to configure slack outgoing webhook URLs without the extra %2F like in https://dev-jenkins.company.com/%2Fslackwebhook/.