### PR TITLE
Support Slack "slash commands"

### DIFF
--- a/src/main/java/jenkins/plugins/slack/webhook/WebhookEndpoint.java
+++ b/src/main/java/jenkins/plugins/slack/webhook/WebhookEndpoint.java
@@ -78,15 +78,14 @@ public class WebhookEndpoint implements UnprotectedRootAction {
                 StaplerResponse.SC_OK);
 
         String triggerWord = data.getTrigger_word();
-        if (triggerWord == null || triggerWord.isEmpty())
-            return new JsonResponse(new SlackTextMessage("Invalid command, trigger_word field required"),
-                StaplerResponse.SC_OK);
-
-        if (!commandText.startsWith(triggerWord))
-            return new JsonResponse(new SlackTextMessage("Invalid command, invalid trigger_word"),
-                StaplerResponse.SC_OK);
-
-        commandText = commandText.trim().replaceFirst(triggerWord, "").trim();
+        if (triggerWord != null && ! triggerWord.isEmpty()) {
+            // A trigger word is present, which is the case when Slack "outgoing webhooks" are used,
+            // as opposed to "slash commands", when the trigger word is absent
+            if (!commandText.startsWith(triggerWord))
+                return new JsonResponse(new SlackTextMessage("Invalid command, invalid trigger_word"),
+                        StaplerResponse.SC_OK);
+            commandText = commandText.trim().replaceFirst(triggerWord, "").trim();
+        }
 
         CommandRouter<SlackTextMessage> router =
             new CommandRouter<SlackTextMessage>();

--- a/src/test/java/jenkins/plugins/slack/webhook/WebhookEndpointTest.java
+++ b/src/test/java/jenkins/plugins/slack/webhook/WebhookEndpointTest.java
@@ -105,13 +105,14 @@ public class WebhookEndpointTest {
 
     @Test
     public void testNoTriggerWordPostData() throws Exception {
+        // No trigger word is present, which is the case when Slack "slash commands" are used
         setConfigSettings();
         List<NameValuePair> goodToken = new ArrayList<NameValuePair>();
         goodToken.add(new NameValuePair("token", "GOOD_TOKEN"));
-        goodToken.add(new NameValuePair("text", "jenkins"));
+        goodToken.add(new NameValuePair("text", "list projects"));
 
         WebResponse response = makeRequest(goodToken);
-        assertThat(getSlackMessage(response).getText(), is("Invalid command, trigger_word field required"));
+        assertThat(getSlackMessage(response).getText(), is("*Projects:*\n>_No projects found_"));
     }
 
     @Test


### PR DESCRIPTION
They are very similar to Slack "outgoing webhooks", but the request from Slack contains no "trigger word".