### PR TITLE
[JENKINS-50706] Fix permission check for credentials

### DIFF
--- a/src/main/java/jenkins/plugins/slack/SlackNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/SlackNotifier.java
@@ -25,6 +25,7 @@ import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
@@ -394,15 +395,18 @@ public class SlackNotifier extends Notifier {
             return sendAs;
         }
 
-        public ListBoxModel doFillTokenCredentialIdItems() {
-            if (!Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER)) {
-                return new ListBoxModel();
+        public ListBoxModel doFillTokenCredentialIdItems(@AncestorInPath Item context) {
+
+            if(context == null && !Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER) ||
+                    context != null && !context.hasPermission(Item.EXTENDED_READ)) {
+                return new StandardListBoxModel();
             }
+
             return new StandardListBoxModel()
                     .withEmptySelection()
                     .withAll(lookupCredentials(
                             StringCredentials.class,
-                            Jenkins.getInstance(),
+                            context,
                             ACL.SYSTEM,
                             new HostnameRequirement("*.slack.com"))
                     );

--- a/src/main/java/jenkins/plugins/slack/workflow/SlackSendStep.java
+++ b/src/main/java/jenkins/plugins/slack/workflow/SlackSendStep.java
@@ -5,6 +5,7 @@ import com.cloudbees.plugins.credentials.domains.HostnameRequirement;
 import hudson.AbortException;
 import hudson.Extension;
 import hudson.Util;
+import hudson.model.Item;
 import hudson.model.Project;
 import hudson.model.TaskListener;
 import hudson.security.ACL;
@@ -166,9 +167,12 @@ public class SlackSendStep extends AbstractStepImpl {
         }
 
         public ListBoxModel doFillTokenCredentialIdItems(@AncestorInPath Project project) {
-            if (!Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER)) {
-                return new ListBoxModel();
+
+            if(project == null && !Jenkins.getInstance().hasPermission(Jenkins.ADMINISTER) ||
+                    project != null && !project.hasPermission(Item.EXTENDED_READ)) {
+                return new StandardListBoxModel();
             }
+
             return new StandardListBoxModel()
                     .withEmptySelection()
                     .withAll(lookupCredentials(


### PR DESCRIPTION
Only administrator are able to select credentials in the job configuration. Which means that when a non admin saves a job, the configuration of the credentials is lost.

@reviewbybees @kmadel 