### PR TITLE
Slack Extension Point

### DIFF
--- a/src/main/java/jenkins/plugins/slack/extension/SlackMessageExtensions.java
+++ b/src/main/java/jenkins/plugins/slack/extension/SlackMessageExtensions.java
@@ -1,0 +1,11 @@
+package jenkins.plugins.slack.extension;
+
+import hudson.ExtensionPoint;
+
+public abstract class SlackMessageExtensions implements ExtensionPoint {
+
+    public String doReplacement(String message) {
+        return message;
+    }
+
+}

--- a/src/test/java/jenkins/plugins/slack/extension/SlackMessageExtensionsTest.java
+++ b/src/test/java/jenkins/plugins/slack/extension/SlackMessageExtensionsTest.java
@@ -1,0 +1,85 @@
+package jenkins.plugins.slack.extension;
+
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.ItemGroup;
+import hudson.model.TaskListener;
+import jenkins.model.Jenkins;
+import jenkins.plugins.slack.ActiveNotifier;
+import jenkins.plugins.slack.SlackNotifier;
+import junit.framework.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import java.io.IOException;
+import java.util.List;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+
+public class SlackMessageExtensionsTest {
+
+    private Jenkins jenkins;
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Before
+    public void setUp() {
+        jenkins = j.getInstance();
+    }
+
+    @Test
+    public void testSlackExtensions() {
+        List<SlackMessageExtensions> extensions = jenkins.getExtensionList(SlackMessageExtensions.class);
+        Assert.assertEquals(1, extensions.size());
+        Assert.assertEquals(InternalExtension.class, extensions.get(0).getClass());
+    }
+
+    @Test
+    public void testReplacement() throws IOException, InterruptedException {
+        FreeStyleBuild build = Mockito.mock(FreeStyleBuild.class);
+        FreeStyleProject project = Mockito.mock(FreeStyleProject.class);
+        SlackNotifier notifier = Mockito.mock(SlackNotifier.class);
+
+        Mockito.when(build.getProject()).thenReturn(project);
+        EnvVars vars = Mockito.mock(EnvVars.class);
+        Mockito.when(build.getEnvironment(any(TaskListener.class))).thenReturn(vars);
+        Mockito.when(build.getDisplayName()).thenReturn("#43 Started by changes from Bob");
+        Mockito.when(vars.expand(anyString())).thenAnswer(new Answer<String>() {
+            @Override
+            public String answer(InvocationOnMock invocation) throws Throwable {
+                Object[] args = invocation.getArguments();
+                return (String) args[0];
+            }
+        });
+
+
+        ItemGroup ig = Mockito.mock(ItemGroup.class);
+        Mockito.when(ig.getFullDisplayName()).thenReturn("");
+        Mockito.when(project.getParent()).thenReturn(ig);
+        Mockito.when(project.getDisplayName()).thenReturn("project");
+
+        Mockito.when(notifier.getCustomMessage()).thenReturn("${INTERNAL_STRING}");
+
+        ActiveNotifier.MessageBuilder messageBuilder = new ActiveNotifier.MessageBuilder(notifier, build);
+        messageBuilder.appendCustomMessage();
+
+        String expectedResult = "project - #43 Started by changes from Bob \n100%";
+
+        Assert.assertEquals(expectedResult, messageBuilder.toString());
+    }
+
+    @Extension
+    public static class InternalExtension extends SlackMessageExtensions {
+        @Override
+        public String doReplacement(String message) {
+            return message.replace("${INTERNAL_STRING}","100%");
+        }
+    }
+
+}


### PR DESCRIPTION
I had a use case where environment variables didn't cut it for the information I wanted to post to slack. I also noticed others mention posting of code coverage and other such stats. In my view trying to squeeze all of this into the Slack Plugin isn't the best from a future maintenance standpoint, so I added an extension point for slack messages. That being said I also have a private plugin which needs to post info to slack and this was the better way of accessing my private classes. 

Basically the way it works is any third parties could register itself as a slack extension just like any other RunListener or Jenkins provided extensions. These extensions will be provided the custom message the user provided in the job at which point they may do any substitutions they would like. The unit test shows an example of this. Note extensions happen prior to environments in case third parties reference environment variables. 

Maybe if there are enough of these it's worth allowing the user to choose which ones are active on a given project but for now just grab all of them. It's the extensions responsibly to provide documentation on how it should be used. While I think something like `${YOUR_KEY}` makes the most sense I didn't enforce it via parsing as I believe it's faster to simply pass the who message around for the time being. 

Let me know what people think about this approach.