### PR TITLE
Enhance Custom Message Functionality (rebased from #169)

### DIFF
--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -199,7 +200,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
         message.append(" file(s) changed)");
         message.appendOpenLink();
         if (includeCustomMessage) {
-            message.appendCustomMessage();
+            message.appendCustomMessage(r.getResult());
         }
         return message.toString();
     }
@@ -265,7 +266,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
             message.appendFailedTests();
         }
         if (includeCustomMessage) {
-            message.appendCustomMessage();
+            message.appendCustomMessage(r.getResult());
         }
         return message.toString();
     }
@@ -432,8 +433,8 @@ public class ActiveNotifier implements FineGrainedNotifier {
             return this;
         }
 
-        public MessageBuilder appendCustomMessage() {
-            String customMessage = notifier.getCustomMessage();
+        public MessageBuilder appendCustomMessage(Result buildResult) {
+            String customMessage = notifier.getCustomMessage(buildResult);
             EnvVars envVars = new EnvVars();
             try {
                 envVars = build.getEnvironment(new LogTaskListener(logger, INFO));

--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -433,6 +433,21 @@ public class ActiveNotifier implements FineGrainedNotifier {
             return this;
         }
 
+        public MessageBuilder appendCustomMessage() {
+            String customMessage = notifier.getCustomMessage();
+            EnvVars envVars = new EnvVars();
+            try {
+                envVars = build.getEnvironment(new LogTaskListener(logger, INFO));
+            } catch (IOException e) {
+                logger.log(SEVERE, e.getMessage(), e);
+            } catch (InterruptedException e) {
+                logger.log(SEVERE, e.getMessage(), e);
+            }
+            message.append("\n");
+            message.append(envVars.expand(customMessage));
+            return this;
+        }
+
         public MessageBuilder appendCustomMessage(Result buildResult) {
             String customMessage = notifier.getCustomMessage(buildResult);
             EnvVars envVars = new EnvVars();

--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
@@ -49,6 +49,21 @@
             <f:entry title="Custom Message" help="/plugin/slack/help-projectConfig-slackCustomMessage.html">
                 <f:textarea name="customMessage" value="${instance.getCustomMessage()}"/>
             </f:entry>
+            <f:entry title="Custom Message - Build Unstable" help="${rootURL}/plugin/slack/help-projectConfig-slackCustomMessage.html">
+                <f:textarea name="customMessageBuildUnstable" value="${instance.getCustomMessage('UNSTABLE')}"/>
+            </f:entry>
+            <f:entry title="Custom Message - Build Aborted" help="${rootURL}/plugin/slack/help-projectConfig-slackCustomMessage.html">
+                <f:textarea name="customMessageBuildAborted" value="${instance.getCustomMessage('ABORTED')}"/>
+            </f:entry>
+            <f:entry title="Custom Message - Build Failure" help="${rootURL}/plugin/slack/help-projectConfig-slackCustomMessage.html">
+                <f:textarea name="customMessageBuildFailure" value="${instance.getCustomMessage('FAILURE')}"/>
+            </f:entry>
+            <f:entry title="Custom Message - Build Not Built" help="${rootURL}/plugin/slack/help-projectConfig-slackCustomMessage.html">
+                <f:textarea name="customMessageBuildNotBuilt" value="${instance.getCustomMessage('NOT_BUILT')}"/>
+            </f:entry>
+            <f:entry title="Custom Message - Success" help="${rootURL}/plugin/slack/help-projectConfig-slackCustomMessage.html">
+                <f:textarea name="customMessageBuildSuccess" value="${instance.getCustomMessage('SUCCESS')}"/>
+            </f:entry>
         </f:optionalBlock>
 
         <f:entry title="Notification message includes" description="What commit information to include into notification message">

--- a/src/test/java/jenkins/plugins/slack/SlackNotifierStub.java
+++ b/src/test/java/jenkins/plugins/slack/SlackNotifierStub.java
@@ -1,15 +1,18 @@
 package jenkins.plugins.slack;
 
+import hudson.model.Result;
+import java.util.HashMap;
+
 public class SlackNotifierStub extends SlackNotifier {
 
     public SlackNotifierStub(String baseUrl, String teamDomain, String authToken, boolean botUser, String room, String authTokenCredentialId,
                              String sendAs, boolean startNotification, boolean notifyAborted, boolean notifyFailure,
                              boolean notifyNotBuilt, boolean notifySuccess, boolean notifyUnstable, boolean notifyRegression, boolean notifyBackToNormal,
                              boolean notifyRepeatedFailure, boolean includeTestSummary, boolean includeFailedTests, 
-                             CommitInfoChoice commitInfoChoice, boolean includeCustomMessage, String customMessage) {
+                             CommitInfoChoice commitInfoChoice, boolean includeCustomMessage, String customMessage, HashMap<String, String> customMessageMap) {
         super(baseUrl, teamDomain, authToken, botUser, room, authTokenCredentialId, sendAs, startNotification, notifyAborted, notifyFailure,
                 notifyNotBuilt, notifySuccess, notifyUnstable, notifyRegression, notifyBackToNormal, notifyRepeatedFailure,
-                includeTestSummary, includeFailedTests, commitInfoChoice, includeCustomMessage, customMessage);
+                includeTestSummary, includeFailedTests, commitInfoChoice, includeCustomMessage, customMessage, customMessageMap);
     }
 
     public static class DescriptorImplStub extends SlackNotifier.DescriptorImpl {

--- a/src/test/java/jenkins/plugins/slack/SlackNotifierTest.java
+++ b/src/test/java/jenkins/plugins/slack/SlackNotifierTest.java
@@ -46,7 +46,8 @@ public class SlackNotifierTest extends TestCase {
         customMessageMap.put("ABORTED", "This is the Aborted Result Message");
         customMessageMap.put("FAILURE", "This is the Failure Result Message");
 
-        this.slackNotifier = new SlackNotifierStub( "teamDomain", "authToken", true, "room", "buildServerUrl", "sendAs", true, true, true, true, true, true, true, true, false, false, CommitInfoChoice.NONE, true, "Custom Message String", customMessageMap);
+        this.slackNotifier = new SlackNotifierStub("baseUrl", "teamDomain", "authToken", true, "room", "buildServerUrl", "sendAs", true, true,
+                true, true, true, true, false, true, true, false, false, CommitInfoChoice.NONE, true, "Custom Message String", customMessageMap);
     }
 
     @Parameterized.Parameters

--- a/src/test/java/jenkins/plugins/slack/SlackNotifierTest.java
+++ b/src/test/java/jenkins/plugins/slack/SlackNotifierTest.java
@@ -1,6 +1,7 @@
 package jenkins.plugins.slack;
 
 import hudson.model.Descriptor;
+import hudson.model.Result;
 import hudson.util.FormValidation;
 import junit.framework.TestCase;
 import net.sf.json.JSONArray;
@@ -13,6 +14,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 
 @RunWith(Parameterized.class)
 public class SlackNotifierTest extends TestCase {
@@ -21,6 +23,7 @@ public class SlackNotifierTest extends TestCase {
     private SlackServiceStub slackServiceStub;
     private boolean response;
     private FormValidation.Kind expectedResult;
+    private SlackNotifierStub slackNotifier;
 
     @Rule
     public final JenkinsRule rule = new JenkinsRule();
@@ -35,6 +38,15 @@ public class SlackNotifierTest extends TestCase {
         this.slackServiceStub = slackServiceStub;
         this.response = response;
         this.expectedResult = expectedResult;
+
+        HashMap<String, String> customMessageMap = new HashMap<String, String>();
+        customMessageMap.put("SUCCESS", "This is the Success Result Message");
+        customMessageMap.put("UNSTABLE", "This is the Unstable Result Message");
+        customMessageMap.put("NOT_BUILT", "This is the Not Built Result Message");
+        customMessageMap.put("ABORTED", "This is the Aborted Result Message");
+        customMessageMap.put("FAILURE", "This is the Failure Result Message");
+
+        this.slackNotifier = new SlackNotifierStub( "teamDomain", "authToken", true, "room", "buildServerUrl", "sendAs", true, true, true, true, true, true, true, true, false, false, CommitInfoChoice.NONE, true, "Custom Message String", customMessageMap);
     }
 
     @Parameterized.Parameters
@@ -59,6 +71,57 @@ public class SlackNotifierTest extends TestCase {
             e.printStackTrace();
             assertTrue(false);
         }
+    }
+
+    /**
+     * Test's the default custom message functionality
+     */
+    @Test
+    public void testSlackNotifierCustomMessage() {
+        String message = slackNotifier.getCustomMessage();
+        assertEquals("Custom Message String", message);
+    }
+
+    /**
+     * Test's enhanced Custom Message functionality
+     */
+    @Test
+    public void testSlackNotifierAdvancedCustomMessageResults() {
+        String message = slackNotifier.getCustomMessage( Result.SUCCESS );
+        assertEquals("This is the Success Result Message", message);
+
+        message = slackNotifier.getCustomMessage( Result.ABORTED );
+        assertEquals("This is the Aborted Result Message", message);
+
+        message = slackNotifier.getCustomMessage( Result.FAILURE );
+        assertEquals("This is the Failure Result Message", message);
+
+        message = slackNotifier.getCustomMessage( Result.NOT_BUILT );
+        assertEquals("This is the Not Built Result Message", message);
+
+        message = slackNotifier.getCustomMessage( Result.UNSTABLE );
+        assertEquals("This is the Unstable Result Message", message);
+    }
+
+    /**
+     * Test's enhanced Custom Message functionality
+     */
+    @Test
+    public void testSlackNotifierAdvancedCustomMessageString() {
+        String message = slackNotifier.getCustomMessage( "SUCCESS" );
+        assertEquals("This is the Success Result Message", message);
+
+        message = slackNotifier.getCustomMessage( "ABORTED" );
+        assertEquals("This is the Aborted Result Message", message);
+
+        message = slackNotifier.getCustomMessage( "FAILURE" );
+        assertEquals("This is the Failure Result Message", message);
+
+        message = slackNotifier.getCustomMessage( "NOT_BUILT" );
+        assertEquals("This is the Not Built Result Message", message);
+
+        message = slackNotifier.getCustomMessage( "UNSTABLE" );
+        assertEquals("This is the Unstable Result Message", message);
     }
 
     public static class SlackServiceStub implements SlackService {


### PR DESCRIPTION
The bd28d4e065fbfe419e6c79d24336f4b25abad156 is a very valuable commit. It makes or breaks the `slack-plugin` experience for me. I took the time to merge it into the current master branch, and fix any problems that arose.

I have no idea how to fix the migration problems that #169 mentioned as the reason of no merge. In my experience, I just had to `configure` the project once and then save it. Afterwards, I could move the custom message where I wanted and it works.

I'm PRing this so that others can see and use it locally.