### PR TITLE
fixes #356: added @DataBoundSetter for includeTestSummary

### DIFF
--- a/src/main/java/jenkins/plugins/slack/SlackNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/SlackNotifier.java
@@ -234,6 +234,11 @@ public class SlackNotifier extends Notifier {
     }
 
     @DataBoundSetter
+    public void setIncludeFailedTests(boolean includeFailedTests) {
+        this.includeFailedTests = includeFailedTests;
+    }
+
+    @DataBoundSetter
     public void setNotifyRepeatedFailure(boolean notifyRepeatedFailure) {
         this.notifyRepeatedFailure = notifyRepeatedFailure;
     }


### PR DESCRIPTION
`includeTestSummary` is not available in the Dynamic DSL of Job-DSL plugin, due to the missing annotation.