### PR TITLE
Reduce verbosity for standard case

### DIFF
--- a/src/main/java/jenkins/plugins/slack/config/JobConfigMigrator.java
+++ b/src/main/java/jenkins/plugins/slack/config/JobConfigMigrator.java
@@ -26,7 +26,7 @@ public class JobConfigMigrator {
 
     public void migrate(final Job<?, ?> job) {
 
-        logger.info(String.format("Migrating job \"%s\" with type %s", job.getName(), job
+        logger.finest(String.format("Migrating job \"%s\" with type %s", job.getName(), job
                 .getClass().getName()));
 
         final SlackJobProperty slackJobProperty = job.getProperty(SlackJobProperty.class);


### PR DESCRIPTION
On every startup I'm getting log lines whereas the migrator does nothing
(because there is nothing to migrate)