### PR TITLE
Add multiple channel comment to slackSend docs

### DIFF
--- a/src/main/resources/jenkins/plugins/slack/workflow/SlackSendStep/help-channel.html
+++ b/src/main/resources/jenkins/plugins/slack/workflow/SlackSendStep/help-channel.html
@@ -1,4 +1,6 @@
 <div>
-    Allows overriding the Slack Plugin channel specified in the global configuration.<br>
+    Allows overriding the Slack Plugin channel specified in the global configuration.
+    Multiple channels may be provided as a comma, semicolon, or space delimited string.
+    <br>
     <code>slackSend channel: "#channel-name", message: "Build Started: ${env.JOB_NAME} ${env.BUILD_NUMBER}"</code>
 </div>


### PR DESCRIPTION
The global plugin configuration where the comment about accepting a csv
string for channels is only rendered in the plugin documentation. This
changes adds that useful piece of knowledge to the slackSend step
documentation like in https://jenkins.io/doc/pipeline/steps/slack/ where
the global config is not easily available.