### PR TITLE
jackson-databind -> 2.8.11.2, security fix, works

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.4.4</version>
+            <version>2.8.11.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
This PR is to update the jackson-databind library to a secure version, per https://nvd.nist.gov/vuln/detail/CVE-2018-7489.

Slack plugin successfully tested with Jenkins ver. 2.142