### PR TITLE
add Token Macro support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,11 @@
             <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>token-macro</artifactId>
+            <version>2.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -1,6 +1,5 @@
 package jenkins.plugins.slack;
 
-import hudson.EnvVars;
 import hudson.Util;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
@@ -21,6 +20,8 @@ import hudson.util.LogTaskListener;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
+import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
+import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 
 import java.io.IOException;
 import java.text.MessageFormat;
@@ -434,16 +435,21 @@ public class ActiveNotifier implements FineGrainedNotifier {
 
         public MessageBuilder appendCustomMessage() {
             String customMessage = notifier.getCustomMessage();
-            EnvVars envVars = new EnvVars();
+
             try {
-                envVars = build.getEnvironment(new LogTaskListener(logger, INFO));
-            } catch (IOException e) {
-                logger.log(SEVERE, e.getMessage(), e);
-            } catch (InterruptedException e) {
+                String replaced = TokenMacro.expandAll(build, new LogTaskListener(logger, INFO), customMessage);
+                message.append("\n");
+                message.append(replaced);
+            }
+            catch (MacroEvaluationException e) {
                 logger.log(SEVERE, e.getMessage(), e);
             }
-            message.append("\n");
-            message.append(envVars.expand(customMessage));
+            catch (IOException e) {
+                logger.log(SEVERE, e.getMessage(), e);
+            }
+            catch (InterruptedException e) {
+                logger.log(SEVERE, e.getMessage(), e);
+            }
             return this;
         }
         


### PR DESCRIPTION
This adds support for the Token Macro Plugin - https://wiki.jenkins.io/display/JENKINS/Token+Macro+Plugin

This allows replacement of tokens from many other plugins. Specifically I wanted support to send Build Failure Analyzer messages, which was discussed here #128 