### PR TITLE
[JENKINS-37339] Prevent NPE after plugin installation

### DIFF
--- a/src/main/java/jenkins/plugins/slack/webhook/WebhookEndpoint.java
+++ b/src/main/java/jenkins/plugins/slack/webhook/WebhookEndpoint.java
@@ -42,13 +42,16 @@ public class WebhookEndpoint implements UnprotectedRootAction {
     private static final Logger LOGGER =
         Logger.getLogger(WebhookEndpoint.class.getName());
 
-    public WebhookEndpoint() {
-        globalConfig = GlobalConfiguration.all().get(GlobalConfig.class);
+    private GlobalConfig getGlobalConfig(){
+        if (globalConfig == null) {
+            this.globalConfig = GlobalConfiguration.all().get(GlobalConfig.class);
+        }
+        return globalConfig;
     }
 
     @Override
     public String getUrlName() {
-        String url = globalConfig.getSlackOutgoingWebhookURL();
+        String url = getGlobalConfig().getSlackOutgoingWebhookURL();
         if (url == null || url.equals(""))
             return UUID.randomUUID().toString().replaceAll("-", "");
 
@@ -59,8 +62,8 @@ public class WebhookEndpoint implements UnprotectedRootAction {
     public HttpResponse doIndex(StaplerRequest req) throws IOException,
         ServletException {
 
-        if (globalConfig.getSlackOutgoingWebhookToken() == null ||
-            globalConfig.getSlackOutgoingWebhookToken().equals("")) {
+        if (getGlobalConfig().getSlackOutgoingWebhookToken() == null ||
+            getGlobalConfig().getSlackOutgoingWebhookToken().equals("")) {
             return new JsonResponse(new SlackTextMessage("Slack token not set"),
                 StaplerResponse.SC_OK); 
         }
@@ -68,7 +71,7 @@ public class WebhookEndpoint implements UnprotectedRootAction {
         SlackPostData data = new SlackPostData();
         req.bindParameters(data);
 
-        if (!globalConfig.getSlackOutgoingWebhookToken().equals(data.getToken()))
+        if (!getGlobalConfig().getSlackOutgoingWebhookToken().equals(data.getToken()))
             return new JsonResponse(new SlackTextMessage("Invalid Slack token"),
                 StaplerResponse.SC_OK); 
     


### PR DESCRIPTION
- due to the way the extension points are implemented, we cannot retrieve one in the constructor (at least not just after the plugin installation)

Seems to solve: [JENKINS-37339](https://issues.jenkins-ci.org/browse/JENKINS-37339), [JENKINS-41420](https://issues.jenkins-ci.org/browse/JENKINS-41420), [JENKINS-53699](https://issues.jenkins-ci.org/browse/JENKINS-53699), [#191](https://github.com/jenkinsci/slack-plugin/issues/191).

@samrocketman @alecharp 