### PR TITLE
Configuration as code compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ credentials:
 
 
 unclassified:
-  slacknotifier:
+  slackNotifier:
     teamDomain: <your-domain>
     tokenCredentialId: <secret-text-token>
 ```

--- a/README.md
+++ b/README.md
@@ -86,6 +86,28 @@ node {
 For more information about slack messages see [Slack Messages Api](https://api.slack.com/docs/messages)
 and [Slack attachments Api](https://api.slack.com/docs/message-attachments)
 
+# Configuration as code
+
+This plugin supports configuration as code
+Add to your yaml file:
+```yaml
+credentials:
+  system:
+    domainCredentials:
+      - credentials:
+          - string:
+              scope: GLOBAL
+              id: slack-token
+              secret: '${SLACK_TOKEN}'
+              description: Slack token
+
+
+unclassified:
+  slacknotifier:
+    teamDomain: <your-domain>
+    tokenCredentialId: <secret-text-token>
+```
+
 # Developer instructions
 
 Install Maven and JDK.

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,11 @@
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>structs</artifactId>
+            <version>1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>display-url-api</artifactId>
             <version>0.4</version>
         </dependency>

--- a/src/main/java/jenkins/plugins/slack/SlackNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/SlackNotifier.java
@@ -63,6 +63,20 @@ public class SlackNotifier extends Notifier {
     private boolean includeCustomMessage;
     private String customMessage;
 
+    /** @deprecated use {@link #tokenCredentialId} */
+    private transient String authTokenCredentialId;
+
+    public String getAuthTokenCredentialId() {
+        return tokenCredentialId;
+    }
+
+    private Object readResolve() {
+        if (this.authTokenCredentialId != null) {
+            this.tokenCredentialId = authTokenCredentialId;
+        }
+        return this;
+    }
+
     @Override
     public DescriptorImpl getDescriptor() {
         return (DescriptorImpl) super.getDescriptor();

--- a/src/main/java/jenkins/plugins/slack/SlackNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/SlackNotifier.java
@@ -356,6 +356,10 @@ public class SlackNotifier extends Notifier {
         private String room;
         private String sendAs;
 
+        public DescriptorImpl() {
+            load();
+        }
+
         public String getBaseUrl() {
             return baseUrl;
         }

--- a/src/main/java/jenkins/plugins/slack/SlackNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/SlackNotifier.java
@@ -22,6 +22,7 @@ import jenkins.model.Jenkins;
 import jenkins.plugins.slack.config.ItemConfigMigrator;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.kohsuke.stapler.AncestorInPath;
@@ -359,7 +360,7 @@ public class SlackNotifier extends Notifier {
         return super.prebuild(build, listener);
     }
 
-    @Extension
+    @Extension @Symbol("slackNotifier")
     public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
 
         private String baseUrl;

--- a/src/main/java/jenkins/plugins/slack/workflow/SlackSendStep.java
+++ b/src/main/java/jenkins/plugins/slack/workflow/SlackSendStep.java
@@ -213,7 +213,7 @@ public class SlackSendStep extends AbstractStepImpl {
                 return null;
             }
             SlackNotifier.DescriptorImpl slackDesc = jenkins.getDescriptorByType(SlackNotifier.DescriptorImpl.class);
-            listener.getLogger().println("run slackstepsend, step " + step.token+":" + step.botUser+", desc " + slackDesc.getToken()+":"+slackDesc.getBotUser());
+            listener.getLogger().println("run slackstepsend, step " + step.token+":" + step.botUser+", desc " + slackDesc.getToken()+":"+slackDesc.isBotUser());
             String baseUrl = step.baseUrl != null ? step.baseUrl : slackDesc.getBaseUrl();
             String team = step.teamDomain != null ? step.teamDomain : slackDesc.getTeamDomain();
             String tokenCredentialId = step.tokenCredentialId != null ? step.tokenCredentialId : slackDesc.getTokenCredentialId();
@@ -224,7 +224,7 @@ public class SlackSendStep extends AbstractStepImpl {
                 botUser = step.botUser;
             } else {
                 token = slackDesc.getToken();
-                botUser = slackDesc.getBotUser();
+                botUser = slackDesc.isBotUser();
             }
             String channel = step.channel != null ? step.channel : slackDesc.getRoom();
             String color = step.color != null ? step.color : "";

--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
@@ -1,89 +1,85 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
     <f:entry title="Notify Build Start">
-        <f:checkbox name="slackStartNotification" value="true" checked="${instance.getStartNotification()}"/>
+        <f:checkbox field="startNotification" />
     </f:entry>
 
     <f:entry title="Notify Aborted">
-        <f:checkbox name="slackNotifyAborted" value="true" checked="${instance.getNotifyAborted()}"/>
+        <f:checkbox field="notifyAborted" />
     </f:entry>
 
     <f:entry title="Notify Failure">
-        <f:checkbox name="slackNotifyFailure" value="true" checked="${instance.getNotifyFailure()}"/>
+        <f:checkbox field="notifyFailure" />
     </f:entry>
 
     <f:entry title="Notify Not Built">
-        <f:checkbox name="slackNotifyNotBuilt" value="true" checked="${instance.getNotifyNotBuilt()}"/>
+        <f:checkbox field="notifyNotBuilt"/>
     </f:entry>
 
     <f:entry title="Notify Success">
-        <f:checkbox name="slackNotifySuccess" value="true" checked="${instance.getNotifySuccess()}"/>
+        <f:checkbox field="notifySuccess" />
     </f:entry>
 
     <f:entry title="Notify Unstable">
-        <f:checkbox name="slackNotifyUnstable" value="true" checked="${instance.getNotifyUnstable()}"/>
+        <f:checkbox field="notifyUnstable" />
     </f:entry>
 
     <f:entry title="Notify Regression">
-        <f:checkbox name="slackNotifyRegression" value="true" checked="${instance.getNotifyRegression()}"/>
+        <f:checkbox field="notifyRegression" />
     </f:entry>
 
 
     <f:entry title="Notify Back To Normal">
-        <f:checkbox name="slackNotifyBackToNormal" value="true" checked="${instance.getNotifyBackToNormal()}"/>
+        <f:checkbox field="notifyBackToNormal" />
     </f:entry>
 
     <f:advanced>
         <f:entry title="Notify Repeated Failure">
-            <f:checkbox name="slackNotifyRepeatedFailure" value="true"
-                        checked="${instance.getNotifyRepeatedFailure()}"/>
+            <f:checkbox field="notifyRepeatedFailure" />
         </f:entry>
         <f:entry title="Include Test Summary">
-            <f:checkbox name="includeTestSummary" value="true" checked="${instance.includeTestSummary()}"/>
+            <f:checkbox field="includeTestSummary" />
         </f:entry>
         <f:entry title="Include Failed Tests">
-            <f:checkbox name="includeFailedTests" value="true" checked="${instance.includeFailedTests()}"/>
+            <f:checkbox field="includeFailedTests" />
         </f:entry>
 
-        <f:optionalBlock name="includeCustomMessage" title="Include Custom Message" checked="${instance.includeCustomMessage()}">
+        <f:optionalBlock title="Include Custom Message">
             <f:entry title="Custom Message" help="/plugin/slack/help-projectConfig-slackCustomMessage.html">
-                <f:textarea name="customMessage" value="${instance.getCustomMessage()}"/>
+                <f:textarea field="customMessage" />
             </f:entry>
         </f:optionalBlock>
 
-        <f:entry title="Notification message includes" description="What commit information to include into notification message">
-            <select class="setting-input" name="slackCommitInfoChoice">
-                <j:forEach var="i" items="${descriptor.COMMIT_INFO_CHOICES}">
-                    <f:option selected="${instance.getCommitInfoChoice()==i}">${i.getDisplayName()}</f:option>
-                </j:forEach>
-            </select>
+        <f:entry field="commitInfoChoice" title="Notification message includes" description="What commit information to include into notification message">
+            <f:select/>
         </f:entry>
 
         <f:entry title="Base URL" help="/plugin/slack/help-projectConfig-slackBaseUrl.html">
-            <f:textbox name="slackBaseUrl" value="${instance.getBaseUrl()}"/>
+            <f:textbox field="baseUrl" />
         </f:entry>
 
         <f:entry title="Team Subdomain" help="/plugin/slack/help-projectConfig-slackTeamDomain.html">
-            <f:textbox name="slackTeamDomain" value="${instance.getTeamDomain()}"/>
+            <f:textbox field="teamDomain" />
         </f:entry>
 
         <f:entry title="Integration Token" help="/plugin/slack/help-projectConfig-slackToken.html">
-            <f:textbox field="token" name="slackToken" value="${instance.getAuthToken()}"/>
+            <f:textbox field="token" />
         </f:entry>
 
-        <f:entry title="Integration Token Credential ID" help="/plugin/slack/help-projectConfig-slackTokenCredentialId.html" field="tokenCredentialId" name="tokenCredentialId" >
-            <c:select value="${instance.getAuthTokenCredentialId()}"/>
+        <f:entry title="Integration Token Credential ID" help="/plugin/slack/help-projectConfig-slackTokenCredentialId.html" field="tokenCredentialId">
+            <c:select />
         </f:entry>
 
         <f:entry title="Is Bot User?" help="/plugin/slack/help-projectConfig-botUser.html">
-            <f:checkbox name="slackBotUser" value="true" checked="${instance.getBotUser()}"/>
+            <f:checkbox field="botUser"/>
         </f:entry>
 
         <f:entry title="Project Channel" help="/plugin/slack/help-projectConfig-slackRoom.html">
-            <f:textbox name="slackRoom" value="${instance.getRoom()}"/>
+            <f:textbox field="room" />
         </f:entry>
         <f:validateButton
                 title="${%Test Connection}" progress="${%Testing...}"
-                method="testConnection" with="slackBaseUrl,slackTeamDomain,slackToken,tokenCredentialId,slackRoom"/>
+                method="testConnection" with="baseUrl,teamDomain,token,tokenCredentialId,botUser,room"/>
     </f:advanced>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/global.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/global.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
   <!--
     This Jelly script is used to produce the global configuration option.
@@ -11,27 +12,27 @@
     tags they use. Views are always organized according to its owner class,
     so it should be straightforward to find them.
   -->
-<f:section title="Global Slack Notifier Settings" name="slack">
+<f:section title="Global Slack Notifier Settings">
     <f:entry title="Base URL" help="/plugin/slack/help-projectConfig-slackBaseUrl.html">
-        <f:textbox field="baseUrl" name="slackBaseUrl" value="${descriptor.getBaseUrl()}"/>
+        <f:textbox field="baseUrl" />
     </f:entry>
     <f:entry title="Team Subdomain" help="/plugin/slack/help-globalConfig-slackTeamDomain.html">
-        <f:textbox field="teamDomain" name="slackTeamDomain" value="${descriptor.getTeamDomain()}" />
+        <f:textbox field="teamDomain" />
     </f:entry>
     <f:entry title="Integration Token" help="/plugin/slack/help-globalConfig-slackToken.html">
-        <f:textbox field="token" name="slackToken" value="${descriptor.getToken()}" />
+        <f:textbox field="token" />
     </f:entry>
-    <f:entry title="Integration Token Credential ID" field="tokenCredentialId" name="tokenCredentialId" help="/plugin/slack/help-globalConfig-tokenCredentialId.html">
+    <f:entry title="Integration Token Credential ID" field="tokenCredentialId" help="/plugin/slack/help-globalConfig-tokenCredentialId.html">
         <c:select/>
     </f:entry>
     <f:entry title="Is Bot User?" help="/plugin/slack/help-globalConfig-botUser.html">
-        <f:checkbox field="botUser" name="slackBotUser" value="true" checked="${descriptor.getBotUser()}" />
+        <f:checkbox field="botUser" />
     </f:entry>
     <f:entry title="Channel" help="/plugin/slack/help-globalConfig-slackRoom.html">
-        <f:textbox field="room" name="slackRoom" value="${descriptor.getRoom()}" />
+        <f:textbox field="room" />
     </f:entry>
     <f:validateButton
         title="${%Test Connection}" progress="${%Testing...}"
-        method="testConnection" with="slackBaseUrl,slackTeamDomain,slackToken,tokenCredentialId,slackRoom" />
+        method="testConnection" with="baseUrl,teamDomain,token,tokenCredentialId,botUser,room" />
   </f:section>
 </j:jelly>

--- a/src/test/java/jenkins/plugins/slack/SlackNotifierTest.java
+++ b/src/test/java/jenkins/plugins/slack/SlackNotifierTest.java
@@ -1,12 +1,11 @@
 package jenkins.plugins.slack;
 
-import hudson.model.Descriptor;
 import hudson.util.FormValidation;
 import junit.framework.TestCase;
 import net.sf.json.JSONArray;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -52,13 +51,9 @@ public class SlackNotifierTest extends TestCase {
             slackServiceStub.setResponse(response);
         }
         descriptor.setSlackService(slackServiceStub);
-        try {
-            FormValidation result = descriptor.doTestConnection("baseUrl", "teamDomain", "authToken", "authTokenCredentialId", false,"room");
-            assertEquals(result.kind, expectedResult);
-        } catch (Descriptor.FormException e) {
-            e.printStackTrace();
-            assertTrue(false);
-        }
+        FormValidation result = descriptor
+                .doTestConnection("baseUrl", "teamDomain", "authToken", "authTokenCredentialId", false, "room");
+        assertEquals(result.kind, expectedResult);
     }
 
     public static class SlackServiceStub implements SlackService {

--- a/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepTest.java
+++ b/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepTest.java
@@ -18,12 +18,15 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.PrintStream;
 import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.Map;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.spy;
 
 /**
@@ -72,7 +75,7 @@ public class SlackSendStepTest {
         stepExecution.listener = taskListenerMock;
 
         when(slackDescMock.getToken()).thenReturn("differentToken");
-        when(slackDescMock.getBotUser()).thenReturn(true);
+        when(slackDescMock.isBotUser()).thenReturn(true);
 
         when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
         doNothing().when(printStreamMock).println();
@@ -104,7 +107,7 @@ public class SlackSendStepTest {
         stepExecution.listener = taskListenerMock;
 
         when(slackDescMock.getToken()).thenReturn("differentToken");
-        when(slackDescMock.getBotUser()).thenReturn(true);
+        when(slackDescMock.isBotUser()).thenReturn(true);
 
         when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
         doNothing().when(printStreamMock).println();
@@ -161,7 +164,7 @@ public class SlackSendStepTest {
         when(slackDescMock.getTeamDomain()).thenReturn("globalTeamDomain");
         when(slackDescMock.getToken()).thenReturn("globalToken");
         when(slackDescMock.getTokenCredentialId()).thenReturn("globalTokenCredentialId");
-        when(slackDescMock.getBotUser()).thenReturn(false);
+        when(slackDescMock.isBotUser()).thenReturn(false);
         when(slackDescMock.getRoom()).thenReturn("globalChannel");
 
         when(taskListenerMock.getLogger()).thenReturn(printStreamMock);


### PR DESCRIPTION
Fixes #396 

I tried to update the core version to allow for unit testing the configuration as code support https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/PLUGINS.md#how-to-test-

but I couldn't make SlackSendStepIntegrationTest#configRoundTrip pass
It would pass if I was in the debugger stepping through, but not running it normally
It would fail with `tokenCredentialId` is null when expected to be `tokenCredentialId`
