### PR TITLE
Documentation - Make option to send notifications to slack users more visible 

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ ID*** field:
 
 ![image][img-token-credential]
 
+# Direct Message
+
+You can send messages to channels or you can notify individual users via their
+slackbot.  In order to notify an individual user, use the syntax `@user_id` in
+place of the project channel.  Mentioning users by display name may work, but it
+is not unique and will not work if it is an ambiguous match.    
+
 # Bot user option
 
 This plugin supports sending notifications via bot users. You can enable bot

--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
@@ -75,7 +75,7 @@
             <f:checkbox field="botUser"/>
         </f:entry>
 
-        <f:entry title="Project Channel" help="/plugin/slack/help-projectConfig-slackRoom.html">
+        <f:entry title="Project Channel or Slack User ID" help="/plugin/slack/help-projectConfig-slackRoom.html">
             <f:textbox field="room" />
         </f:entry>
         <f:validateButton

--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/global.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/global.jelly
@@ -28,7 +28,7 @@
     <f:entry title="Is Bot User?" help="/plugin/slack/help-globalConfig-botUser.html">
         <f:checkbox field="botUser" />
     </f:entry>
-    <f:entry title="Project Channel or Slack ID" help="/plugin/slack/help-globalConfig-slackRoom.html">
+    <f:entry title="Channel or Slack ID" help="/plugin/slack/help-globalConfig-slackRoom.html">
         <f:textbox field="room" />
     </f:entry>
     <f:validateButton

--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/global.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/global.jelly
@@ -28,7 +28,7 @@
     <f:entry title="Is Bot User?" help="/plugin/slack/help-globalConfig-botUser.html">
         <f:checkbox field="botUser" />
     </f:entry>
-    <f:entry title="Channel" help="/plugin/slack/help-globalConfig-slackRoom.html">
+    <f:entry title="Project Channel or Slack ID" help="/plugin/slack/help-globalConfig-slackRoom.html">
         <f:textbox field="room" />
     </f:entry>
     <f:validateButton

--- a/src/main/webapp/help-globalConfig-slackRoom.html
+++ b/src/main/webapp/help-globalConfig-slackRoom.html
@@ -1,8 +1,8 @@
 <div>
   <p>
-    Enter the channel names to which notifications should be sent. Note that this can include names of
+    Enter the channel names or user ids to which notifications should be sent. Note that this can include names of
     channels OR channel id numbers, e.g. "#builds", and that multiple values may appear comma separated.
-    While names are more readable, channel ids will not change over time and are therefore more resilient. 
+    While names are more readable, channel ids will not change over time and are therefore more resilient.
   </p>
   <p>
 	It is possible to override this setting per project.

--- a/src/main/webapp/help-projectConfig-slackRoom.html
+++ b/src/main/webapp/help-projectConfig-slackRoom.html
@@ -1,8 +1,8 @@
 <div>
   <p>
-    Enter the channel names to which notifications should be sent. Note that this can include names of
+    Enter the channel names or user ids to which notifications should be sent. Note that this can include names of
     channels OR channel id numbers, e.g. "#builds", and that multiple values may appear comma separated.
-    While names are more readable, channel ids will not change over time and are therefore more resilient. 
+    While names are more readable, channel ids will not change over time and are therefore more resilient.
   </p>
   <p>
 	This overrides the global setting.


### PR DESCRIPTION
When using this plugin , I didn't realize that you could send notifications to slack users until I just tried it and it worked.  I saw after the fact that it is shown in the Jenkinsfile example.  

Happy to have the language changed from what is in this PR, I just want it to be more visible in some way to users that this is an option.  