### PR TITLE
Fix configuration as code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ credentials:
 
 unclassified:
   slackNotifier:
-    teamDomain: <your-domain>
-    tokenCredentialId: <secret-text-token>
+    teamDomain: <your-slack-workspace-name> # i.e. your-company (just the workspace name not the full url)
+    tokenCredentialId: slack-token
 ```
 
 # Developer instructions


### PR DESCRIPTION
`slack-token` should have been referred to in the `tokenCredentialId`