### PR TITLE
Pipeline response object

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,23 @@ node {
 For more information about slack messages see [Slack Messages Api](https://api.slack.com/docs/messages)
 and [Slack attachments Api](https://api.slack.com/docs/message-attachments)
 
+## Threads Support
+
+You can send a message and create a thread on that message using the pipeline step.
+The step returns an object which you can use to retrieve the thread ID. Send new messages with that thread ID as the
+target channel to create a thread. All messages of a thread should use the same thread ID.
+
+Example:
+```
+node {
+    def slackResponse = slackSend(channel: "cool-threads", message: "Here is the primary message")
+    slackSend(channel: slackResponse.threadId, message: "Thread reply #1")
+    slackSend(channel: slackResponse.threadId, message: "Thread reply #2")
+}
+```
+
+This feature requires botUser mode.
+
 # Configuration as code
 
 This plugin supports configuration as code

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,11 @@
             <version>1.3</version>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>script-security</artifactId>
+            <version>1.30</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.8.11.2</version>

--- a/src/main/java/jenkins/plugins/slack/SlackService.java
+++ b/src/main/java/jenkins/plugins/slack/SlackService.java
@@ -9,4 +9,6 @@ public interface SlackService {
     boolean publish(String message, String color);
 
     boolean publish(JSONArray attachments, String color);
+
+    String getResponseString();
 }

--- a/src/main/java/jenkins/plugins/slack/StandardSlackService.java
+++ b/src/main/java/jenkins/plugins/slack/StandardSlackService.java
@@ -154,7 +154,9 @@ public class StandardSlackService implements SlackService {
 
             	int responseCode = response.getStatusLine().getStatusCode();
             	HttpEntity entity = response.getEntity();
-            	responseString = EntityUtils.toString(entity);
+            	if (entity != null) {
+                    responseString = EntityUtils.toString(entity);
+                }
             	if(responseCode != HttpStatus.SC_OK) {
             		 logger.log(Level.WARNING, "Slack post may have failed. Response: " + responseString);
             		 logger.log(Level.WARNING, "Response Code: " + responseCode);

--- a/src/main/java/jenkins/plugins/slack/StandardSlackService.java
+++ b/src/main/java/jenkins/plugins/slack/StandardSlackService.java
@@ -154,7 +154,7 @@ public class StandardSlackService implements SlackService {
 
             	int responseCode = response.getStatusLine().getStatusCode();
             	HttpEntity entity = response.getEntity();
-                responseString = EntityUtils.toString(entity);
+            	responseString = EntityUtils.toString(entity);
             	if(responseCode != HttpStatus.SC_OK) {
             		 logger.log(Level.WARNING, "Slack post may have failed. Response: " + responseString);
             		 logger.log(Level.WARNING, "Response Code: " + responseCode);
@@ -203,14 +203,14 @@ public class StandardSlackService implements SlackService {
             if (proxy != null) {
                 final HttpHost proxyHost = new HttpHost(proxy.name, proxy.port);
                 final HttpRoutePlanner routePlanner = new DefaultProxyRoutePlanner(proxyHost);
-                clientBuilder.setRoutePlanner(routePlanner);                
+                clientBuilder.setRoutePlanner(routePlanner);
 
                 String username = proxy.getUserName();
                 String password = proxy.getPassword();
                 // Consider it to be passed if username specified. Sufficient?
                 if (username != null && !"".equals(username.trim())) {
                     logger.info("Using proxy authentication (user=" + username + ")");
-                    credentialsProvider.setCredentials(new AuthScope(proxyHost), 
+                    credentialsProvider.setCredentials(new AuthScope(proxyHost),
                     								   new UsernamePasswordCredentials(username, password));
                 }
             }

--- a/src/main/java/jenkins/plugins/slack/StandardSlackService.java
+++ b/src/main/java/jenkins/plugins/slack/StandardSlackService.java
@@ -53,6 +53,7 @@ public class StandardSlackService implements SlackService {
     private String authTokenCredentialId;
     private boolean botUser;
     private String[] roomIds;
+    private String responseString = null;
 
     public StandardSlackService(String baseUrl, String teamDomain, String token, String authTokenCredentialId, boolean botUser, String roomId) {
         super();
@@ -65,6 +66,10 @@ public class StandardSlackService implements SlackService {
         this.authTokenCredentialId = StringUtils.trim(authTokenCredentialId);
         this.botUser = botUser;
         this.roomIds = roomId.split("[,; ]+");
+    }
+
+    public String getResponseString() {
+        return responseString;
     }
 
     public boolean publish(String message) {
@@ -146,11 +151,11 @@ public class StandardSlackService implements SlackService {
             try {
             	post.setEntity(new UrlEncodedFormEntity(nvps, "UTF-8"));
             	CloseableHttpResponse response = client.execute(post);
-            	
+
             	int responseCode = response.getStatusLine().getStatusCode();
+            	HttpEntity entity = response.getEntity();
+                responseString = EntityUtils.toString(entity);
             	if(responseCode != HttpStatus.SC_OK) {
-            		 HttpEntity entity = response.getEntity();
-            		 String responseString = EntityUtils.toString(entity);
             		 logger.log(Level.WARNING, "Slack post may have failed. Response: " + responseString);
             		 logger.log(Level.WARNING, "Response Code: " + responseCode);
             		 result = false;

--- a/src/main/java/jenkins/plugins/slack/StandardSlackService.java
+++ b/src/main/java/jenkins/plugins/slack/StandardSlackService.java
@@ -154,7 +154,7 @@ public class StandardSlackService implements SlackService {
 
             	int responseCode = response.getStatusLine().getStatusCode();
             	HttpEntity entity = response.getEntity();
-            	if (entity != null) {
+            	if (botUser && entity != null) {
                     responseString = EntityUtils.toString(entity);
                 }
             	if(responseCode != HttpStatus.SC_OK) {

--- a/src/main/java/jenkins/plugins/slack/workflow/SlackResponse.java
+++ b/src/main/java/jenkins/plugins/slack/workflow/SlackResponse.java
@@ -1,5 +1,6 @@
 package jenkins.plugins.slack.workflow;
 
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.json.JSONObject;
 
@@ -10,9 +11,11 @@ public class SlackResponse implements Serializable {
     private String ts;
 
     public SlackResponse(String slackResponseString) {
-        JSONObject result = new JSONObject(slackResponseString);
-        channelId = result.getString("channel");
-        ts = result.getString("ts");
+        if (StringUtils.isEmpty(slackResponseString)) {
+            JSONObject result = new JSONObject(slackResponseString);
+            channelId = result.getString("channel");
+            ts = result.getString("ts");
+        }
     }
 
     @Whitelisted
@@ -27,6 +30,10 @@ public class SlackResponse implements Serializable {
 
     @Whitelisted
     public String getThreadId() {
-        return channelId + ":" + ts;
+        if (!StringUtils.isEmpty(channelId) && !StringUtils.isEmpty(ts)) {
+            return channelId + ":" + ts;
+        } else {
+            return null;
+        }
     }
 }

--- a/src/main/java/jenkins/plugins/slack/workflow/SlackResponse.java
+++ b/src/main/java/jenkins/plugins/slack/workflow/SlackResponse.java
@@ -11,7 +11,7 @@ public class SlackResponse implements Serializable {
     private String ts;
 
     public SlackResponse(String slackResponseString) {
-        if (StringUtils.isEmpty(slackResponseString)) {
+        if (!StringUtils.isEmpty(slackResponseString)) {
             JSONObject result = new JSONObject(slackResponseString);
             channelId = result.getString("channel");
             ts = result.getString("ts");

--- a/src/main/java/jenkins/plugins/slack/workflow/SlackResponse.java
+++ b/src/main/java/jenkins/plugins/slack/workflow/SlackResponse.java
@@ -9,9 +9,6 @@ public class SlackResponse implements Serializable {
     private String channelId;
     private String ts;
 
-    public SlackResponse() {
-    }
-
     public SlackResponse(String slackResponseString) {
         JSONObject result = new JSONObject(slackResponseString);
         channelId = result.getString("channel");

--- a/src/main/java/jenkins/plugins/slack/workflow/SlackResponse.java
+++ b/src/main/java/jenkins/plugins/slack/workflow/SlackResponse.java
@@ -1,0 +1,35 @@
+package jenkins.plugins.slack.workflow;
+
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
+import org.json.JSONObject;
+
+import java.io.Serializable;
+
+public class SlackResponse implements Serializable {
+    private String channelId;
+    private String ts;
+
+    public SlackResponse() {
+    }
+
+    public SlackResponse(String slackResponseString) {
+        JSONObject result = new JSONObject(slackResponseString);
+        channelId = result.getString("channel");
+        ts = result.getString("ts");
+    }
+
+    @Whitelisted
+    public String getChannelId() {
+        return channelId;
+    }
+
+    @Whitelisted
+    public String getTs() {
+        return ts;
+    }
+
+    @Whitelisted
+    public String getThreadId() {
+        return channelId + ":" + ts;
+    }
+}

--- a/src/main/java/jenkins/plugins/slack/workflow/SlackSendStep.java
+++ b/src/main/java/jenkins/plugins/slack/workflow/SlackSendStep.java
@@ -266,9 +266,7 @@ public class SlackSendStep extends AbstractStepImpl {
             SlackResponse response = null;
             if (publishSuccess) {
                 String responseString = slackService.getResponseString();
-                if (responseString != null) {
-                    response = new SlackResponse(responseString);
-                }
+                response = new SlackResponse(responseString);
             } else if (step.failOnError) {
                 throw new AbortException(Messages.NotificationFailed());
             } else {

--- a/src/main/java/jenkins/plugins/slack/workflow/SlackSendStep.java
+++ b/src/main/java/jenkins/plugins/slack/workflow/SlackSendStep.java
@@ -259,8 +259,7 @@ public class SlackSendStep extends AbstractStepImpl {
             }
             SlackResponse response = null;
             if (publishSuccess) {
-                StandardSlackService standardSlackService = (StandardSlackService) slackService;
-                String responseString = standardSlackService.getResponseString();
+                String responseString = slackService.getResponseString();
                 if (responseString != null) {
                     response = new SlackResponse(responseString);
                 }

--- a/src/test/java/jenkins/plugins/slack/SlackNotifierTest.java
+++ b/src/test/java/jenkins/plugins/slack/SlackNotifierTest.java
@@ -76,5 +76,7 @@ public class SlackNotifierTest extends TestCase {
         public void setResponse(boolean response) {
             this.response = response;
         }
+
+        public String getResponseString() { return null; }
     }
 }

--- a/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepTest.java
+++ b/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepTest.java
@@ -217,7 +217,8 @@ public class SlackSendStepTest {
     public void testSlackResponseObject() throws Exception {
 
         SlackSendStep.SlackSendStepExecution stepExecution = spy(new SlackSendStep.SlackSendStepExecution());
-        SlackSendStep slackSendStep = new SlackSendStep("message");
+        SlackSendStep slackSendStep = new SlackSendStep();
+        slackSendStep.setMessage("message");
         slackSendStep.setToken("token");
         slackSendStep.setTokenCredentialId("tokenCredentialId");
         slackSendStep.setBotUser(true);
@@ -244,8 +245,10 @@ public class SlackSendStepTest {
         SlackResponse response = stepExecution.run();
         String expectedId = "F4KE1DABC";
         String expectedTs = "1543931401.000500";
+        String expectedThreadId = "F4KE1DABC:1543931401.000500";
         assertNotNull(response);
         assertEquals(expectedId, response.getChannelId());
         assertEquals(expectedTs, response.getTs());
+        assertEquals(expectedThreadId, response.getThreadId());
     }
 }

--- a/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepTest.java
+++ b/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepTest.java
@@ -250,5 +250,39 @@ public class SlackSendStepTest {
         assertEquals(expectedId, response.getChannelId());
         assertEquals(expectedTs, response.getTs());
         assertEquals(expectedThreadId, response.getThreadId());
+
+    }
+
+    @Test
+    public void testSlackResponseObjectNullNonBotUser() throws Exception {
+
+        SlackSendStep.SlackSendStepExecution stepExecution = spy(new SlackSendStep.SlackSendStepExecution());
+        SlackSendStep slackSendStep = new SlackSendStep();
+        slackSendStep.setMessage("message");
+        slackSendStep.setToken("token");
+        slackSendStep.setTokenCredentialId("tokenCredentialId");
+        slackSendStep.setBotUser(false);
+        slackSendStep.setBaseUrl("baseUrl/");
+        slackSendStep.setTeamDomain("teamDomain");
+        slackSendStep.setChannel("channel");
+        slackSendStep.setColor("good");
+        stepExecution.step = slackSendStep;
+
+        when(Jenkins.getActiveInstance()).thenReturn(jenkins);
+
+        stepExecution.listener = taskListenerMock;
+        when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
+        doNothing().when(printStreamMock).println();
+
+        when(stepExecution.getSlackService(anyString(), anyString(), anyString(), anyString(), anyBoolean(), anyString())).thenReturn(slackServiceMock);
+
+        when(slackServiceMock.getResponseString()).thenReturn("ok");
+        when(slackServiceMock.publish(anyString(), anyString())).thenReturn(true);
+
+        SlackResponse response = stepExecution.run();
+        assertNotNull(response);
+        assertNull(response.getChannelId());
+        assertNull(response.getTs());
+        assertNull(response.getThreadId());
     }
 }

--- a/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepTest.java
+++ b/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepTest.java
@@ -7,6 +7,7 @@ import jenkins.plugins.slack.SlackNotifier;
 import jenkins.plugins.slack.SlackService;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
+import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.junit.Before;
 import org.junit.Test;
@@ -52,14 +53,6 @@ public class SlackSendStepTest {
     Jenkins jenkins;
     @Mock
     SlackNotifier.DescriptorImpl slackDescMock;
-
-    String savedResponse = "{\"ok\":true,\"channel\":\"F4KE1DABC\",\"ts\":\"1543931401.000500\"," +
-            "\"message\":{\"bot_id\":\"F4KEB0T\",\"type\":\"message\",\"text\":\"\",\"user\":\"F4KEUSR\"," +
-            "\"ts\":\"1543931401.000500\",\"attachments\":[{\"fallback\":\"hi\",\"id\":1," +
-            "\"fields\":[{\"title\":\"\",\"value\":\"hi\",\"short\":false}]," +
-            "\"mrkdwn_in\":[\"pretext\",\"text\",\"fields\"]}]}," +
-            "\"warning\":\"superfluous_charset\"," +
-            "\"response_metadata\":{\"warnings\":[\"superfluous_charset\"]}}";
 
     @Before
     public void setUp() {
@@ -236,6 +229,10 @@ public class SlackSendStepTest {
         doNothing().when(printStreamMock).println();
 
         when(stepExecution.getSlackService(anyString(), anyString(), anyString(), anyString(), anyBoolean(), anyString())).thenReturn(slackServiceMock);
+
+        String savedResponse = IOUtils.toString(
+                this.getClass().getResourceAsStream("response.json")
+        );
         when(slackServiceMock.getResponseString()).thenReturn(savedResponse);
         when(slackServiceMock.publish(anyString(), anyString())).thenReturn(true);
 

--- a/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepTest.java
+++ b/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepTest.java
@@ -276,7 +276,7 @@ public class SlackSendStepTest {
 
         when(stepExecution.getSlackService(anyString(), anyString(), anyString(), anyString(), anyBoolean(), anyString())).thenReturn(slackServiceMock);
 
-        when(slackServiceMock.getResponseString()).thenReturn("ok");
+        when(slackServiceMock.getResponseString()).thenReturn(null);
         when(slackServiceMock.publish(anyString(), anyString())).thenReturn(true);
 
         SlackResponse response = stepExecution.run();

--- a/src/test/resources/jenkins/plugins/slack/workflow/response.json
+++ b/src/test/resources/jenkins/plugins/slack/workflow/response.json
@@ -1,0 +1,1 @@
+{"ok":true,"channel":"F4KE1DABC","ts":"1543931401.000500","message":{"bot_id":"F4KEB0T","type":"message","text":"","user":"F4KEUSR","ts":"1543931401.000500","attachments":[{"fallback":"hi","id":1,"fields":[{"title":"","value":"hi","short":false}],"mrkdwn_in":["pretext","text","fields"]}]},"warning":"superfluous_charset","response_metadata":{"warnings":["superfluous_charset"]}}


### PR DESCRIPTION
This allows the pipeline step to return an object with some response information. The main reason for this addition is to allow subsequent messages to be added as a thread on an initial message. It builds upon the thread support added in a recent PR.

Example usage in a Jenkinsfile:
`response = slackSend botUser: true, channel: 'general', message: 'Hello'
slackSend botUser: true, channel: "${response.threadId}", message: 'this is a thread response of the initial message'`