### PR TITLE
Fix serialisation of some fields

### DIFF
--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -68,7 +68,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
                 MessageBuilder message = new MessageBuilder(notifier, build);
                 message.append(causeAction.getCauses().get(0).getShortDescription());
                 message.appendOpenLink();
-                if (notifier.includeCustomMessage()) {
+                if (notifier.getIncludeCustomMessage()) {
                   message.appendCustomMessage();
                 }
                 notifyStart(build, message.toString());
@@ -77,11 +77,11 @@ public class ActiveNotifier implements FineGrainedNotifier {
             }
         }
 
-        String changes = getChanges(build, notifier.includeCustomMessage());
+        String changes = getChanges(build, notifier.getIncludeCustomMessage());
         if (changes != null) {
             notifyStart(build, changes);
         } else {
-            notifyStart(build, getBuildStatusMessage(build, false, false, notifier.includeCustomMessage()));
+            notifyStart(build, getBuildStatusMessage(build, false, false, notifier.getIncludeCustomMessage()));
         }
     }
 
@@ -110,8 +110,8 @@ public class ActiveNotifier implements FineGrainedNotifier {
             } while (previousBuild != null && previousBuild.getResult() == Result.ABORTED);
             Result previousResult = (previousBuild != null) ? previousBuild.getResult() : Result.SUCCESS;
             if(null != previousResult && (result.isWorseThan(previousResult) || moreTestFailuresThanPreviousBuild(r, previousBuild)) && notifier.getNotifyRegression()) {
-                getSlack(r).publish(getBuildStatusMessage(r, notifier.includeTestSummary(),
-                        notifier.includeFailedTests(), notifier.includeCustomMessage()), getBuildColor(r));
+                getSlack(r).publish(getBuildStatusMessage(r, notifier.getIncludeTestSummary(),
+                        notifier.getIncludeFailedTests(), notifier.getIncludeCustomMessage()), getBuildColor(r));
                 if (notifier.getCommitInfoChoice().showAnything()) {
                     getSlack(r).publish(getCommitList(r), getBuildColor(r));
                 }
@@ -141,8 +141,8 @@ public class ActiveNotifier implements FineGrainedNotifier {
                         && notifier.getNotifyBackToNormal())
                     || (result == Result.SUCCESS && notifier.getNotifySuccess())
                     || (result == Result.UNSTABLE && notifier.getNotifyUnstable())) {
-                getSlack(r).publish(getBuildStatusMessage(r, notifier.includeTestSummary(),
-                        notifier.includeFailedTests(), notifier.includeCustomMessage()), getBuildColor(r));
+                getSlack(r).publish(getBuildStatusMessage(r, notifier.getIncludeTestSummary(),
+                        notifier.getIncludeFailedTests(), notifier.getIncludeCustomMessage()), getBuildColor(r));
                 if (notifier.getCommitInfoChoice().showAnything()) {
                     getSlack(r).publish(getCommitList(r), getBuildColor(r));
                 }

--- a/src/main/java/jenkins/plugins/slack/SlackNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/SlackNotifier.java
@@ -176,11 +176,11 @@ public class SlackNotifier extends Notifier {
         return notifyBackToNormal;
     }
 
-    public boolean includeTestSummary() {
+    public boolean getIncludeTestSummary() {
         return includeTestSummary;
     }
 
-    public boolean includeFailedTests() {
+    public boolean getIncludeFailedTests() {
         return includeFailedTests;
     }
 
@@ -188,7 +188,7 @@ public class SlackNotifier extends Notifier {
         return notifyRepeatedFailure;
     }
 
-    public boolean includeCustomMessage() {
+    public boolean getIncludeCustomMessage() {
         return includeCustomMessage;
     }
 
@@ -296,7 +296,11 @@ public class SlackNotifier extends Notifier {
         this.includeFailedTests = includeFailedTests;
         this.commitInfoChoice = commitInfoChoice;
         this.includeCustomMessage = includeCustomMessage;
-        this.customMessage = customMessage;
+        if (includeCustomMessage) {
+            this.customMessage = customMessage;
+        } else {
+            this.customMessage = null;
+        }
     }
 
     public BuildStepMonitor getRequiredMonitorService() {
@@ -681,7 +685,7 @@ public class SlackNotifier extends Notifier {
         }
 
         @Exported
-        public boolean includeTestSummary() {
+        public boolean getIncludeTestSummary() {
             return includeTestSummary;
         }
 
@@ -691,7 +695,7 @@ public class SlackNotifier extends Notifier {
         }
 
         @Exported
-        public boolean includeCustomMessage() {
+        public boolean getIncludeCustomMessage() {
             return includeCustomMessage;
         }
 

--- a/src/main/java/jenkins/plugins/slack/config/AbstractProjectConfigMigrator.java
+++ b/src/main/java/jenkins/plugins/slack/config/AbstractProjectConfigMigrator.java
@@ -83,9 +83,9 @@ public class AbstractProjectConfigMigrator {
         slackNotifier.setNotifyBackToNormal(slackJobProperty.getNotifyBackToNormal());
         slackNotifier.setNotifyRepeatedFailure(slackJobProperty.getNotifyRepeatedFailure());
 
-        slackNotifier.setIncludeTestSummary(slackJobProperty.includeTestSummary());
+        slackNotifier.setIncludeTestSummary(slackJobProperty.getIncludeTestSummary());
         slackNotifier.setCommitInfoChoice(getCommitInfoChoice(slackJobProperty));
-        slackNotifier.setIncludeCustomMessage(slackJobProperty.includeCustomMessage());
+        slackNotifier.setIncludeCustomMessage(slackJobProperty.getIncludeCustomMessage());
         slackNotifier.setCustomMessage(slackJobProperty.getCustomMessage());
     }
 

--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
@@ -1,6 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
     <f:entry title="Notify Build Start">
         <f:checkbox field="startNotification" />
     </f:entry>
@@ -45,11 +44,13 @@
             <f:checkbox field="includeFailedTests" />
         </f:entry>
 
-        <f:optionalBlock title="Include Custom Message">
-            <f:entry title="Custom Message" help="/plugin/slack/help-projectConfig-slackCustomMessage.html">
-                <f:textarea field="customMessage" />
+        <f:optionalBlock title="Include Custom Message" name="includeCustomMessage" inline="true"
+            checked="${instance.customMessage != null}">
+            <f:entry title="Custom Message" field="customMessage" help="/plugin/slack/help-projectConfig-slackCustomMessage.html">
+                <f:textarea />
             </f:entry>
         </f:optionalBlock>
+
 
         <f:entry field="commitInfoChoice" title="Notification message includes" description="What commit information to include into notification message">
             <f:select/>

--- a/src/test/java/jenkins/plugins/slack/config/BackwordsCompatible_1_8_SlackNotifierTest.java
+++ b/src/test/java/jenkins/plugins/slack/config/BackwordsCompatible_1_8_SlackNotifierTest.java
@@ -54,9 +54,9 @@ public class BackwordsCompatible_1_8_SlackNotifierTest {
         assertTrue(notifier.getNotifyFailure());
         assertFalse(notifier.getNotifyBackToNormal());
         assertFalse(notifier.getNotifyRepeatedFailure());
-        assertFalse(notifier.includeTestSummary());
+        assertFalse(notifier.getIncludeTestSummary());
         assertEquals(CommitInfoChoice.NONE, notifier.getCommitInfoChoice());
-        assertFalse(notifier.includeCustomMessage());
+        assertFalse(notifier.getIncludeCustomMessage());
         assertEquals("", notifier.getCustomMessage());
 
         assertNull(project.getProperty(SlackJobProperty.class));
@@ -82,9 +82,9 @@ public class BackwordsCompatible_1_8_SlackNotifierTest {
         assertTrue(notifier.getNotifyFailure());
         assertFalse(notifier.getNotifyBackToNormal());
         assertFalse(notifier.getNotifyRepeatedFailure());
-        assertFalse(notifier.includeTestSummary());
+        assertFalse(notifier.getIncludeTestSummary());
         assertEquals(CommitInfoChoice.NONE, notifier.getCommitInfoChoice());
-        assertFalse(notifier.includeCustomMessage());
+        assertFalse(notifier.getIncludeCustomMessage());
         assertEquals("", notifier.getCustomMessage());
 
         assertNull(project.getProperty(SlackJobProperty.class));
@@ -110,9 +110,9 @@ public class BackwordsCompatible_1_8_SlackNotifierTest {
         assertTrue(notifier.getNotifyFailure());
         assertFalse(notifier.getNotifyBackToNormal());
         assertFalse(notifier.getNotifyRepeatedFailure());
-        assertFalse(notifier.includeTestSummary());
+        assertFalse(notifier.getIncludeTestSummary());
         assertEquals(CommitInfoChoice.NONE, notifier.getCommitInfoChoice());
-        assertFalse(notifier.includeCustomMessage());
+        assertFalse(notifier.getIncludeCustomMessage());
         assertEquals("", notifier.getCustomMessage());
 
         assertNull(project.getProperty(SlackJobProperty.class));
@@ -166,9 +166,9 @@ public class BackwordsCompatible_1_8_SlackNotifierTest {
         assertTrue(notifier.getNotifyFailure());
         assertTrue(notifier.getNotifyBackToNormal());
         assertTrue(notifier.getNotifyRepeatedFailure());
-        assertTrue(notifier.includeTestSummary());
+        assertTrue(notifier.getIncludeTestSummary());
         assertEquals(CommitInfoChoice.AUTHORS_AND_TITLES, notifier.getCommitInfoChoice());
-        assertTrue(notifier.includeCustomMessage());
+        assertTrue(notifier.getIncludeCustomMessage());
         assertEquals("Custom message for 1.8 plugin.", notifier.getCustomMessage());
 
         assertNull(project2.getProperty(SlackJobProperty.class));


### PR DESCRIPTION
Getters were named wrong for:
* includeTestSummary
* includeFailedTests

Missing inline, name and checked attribute on the jelly for:
* includeCustomMessage
* customMessage