### PR TITLE
Adding basic info to job console output

### DIFF
--- a/src/main/java/jenkins/plugins/slack/SlackNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/SlackNotifier.java
@@ -431,6 +431,25 @@ public class SlackNotifier extends Notifier {
     @Override
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
         logger.info("Performing complete notifications");
+        String teamDomain = this.getTeamDomain();
+        if (StringUtils.isEmpty(teamDomain)) {
+            teamDomain = getDescriptor().getTeamDomain();
+        }
+        if (StringUtils.isEmpty(teamDomain)) {
+            teamDomain = "";
+        } else {
+            teamDomain = " on Team Subdomain: " + teamDomain;
+        }
+        String room = this.getRoom();
+        if (StringUtils.isEmpty(room)) {
+            room = getDescriptor().getRoom();
+        }
+        if (StringUtils.isEmpty(room)) {
+            listener.getLogger().println("[INFO] Slack notifications enabled in post-build but no Channel was found in the job or global config");
+        } else {
+            listener.getLogger().println("[INFO] Slack notifications will be sent to the following channels: " + room + teamDomain);
+        }
+
         new ActiveNotifier((SlackNotifier) this, listener).completed(build);
         if (notifyRegression) {
             logger.info("Performing finalize notifications");

--- a/src/test/java/jenkins/plugins/slack/SlackNotifierStub.java
+++ b/src/test/java/jenkins/plugins/slack/SlackNotifierStub.java
@@ -14,6 +14,8 @@ public class SlackNotifierStub extends SlackNotifier {
                 customMessageAborted, customMessageNotBuilt, customMessageUnstable, customMessageFailure);
     }
 
+    public DescriptorImplStub descriptorImplStub;
+
     public static class DescriptorImplStub extends SlackNotifier.DescriptorImpl {
 
         private SlackService slackService;
@@ -30,5 +32,14 @@ public class SlackNotifierStub extends SlackNotifier {
         public void setSlackService(SlackService slackService) {
             this.slackService = slackService;
         }
+    }
+
+    public void setDescriptor(DescriptorImplStub descriptorImplStub) {
+        this.descriptorImplStub = descriptorImplStub;
+    }
+
+    @Override
+    public DescriptorImpl getDescriptor() {
+        return descriptorImplStub;
     }
 }


### PR DESCRIPTION
Before this change all logging was done in the jenkins administration logs
This adds a simple console output in the job console, in parity with
what the hipchat plugin prints. Without this change users cannot tell
if the publisher (post-build) action for slack is running.