### PR TITLE
Fix job based settings save / set DataBoundConstructor correctly

### DIFF
--- a/src/main/java/jenkins/plugins/slack/SlackNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/SlackNotifier.java
@@ -316,7 +316,6 @@ public class SlackNotifier extends Notifier {
         this.customMessageFailure = customMessageFailure;
     }
 
-    @DataBoundConstructor
     public SlackNotifier(CommitInfoChoice commitInfoChoice) {
         this.commitInfoChoice = commitInfoChoice;
     }
@@ -335,6 +334,7 @@ public class SlackNotifier extends Notifier {
         );
     }
 
+    @DataBoundConstructor
     public SlackNotifier(final String baseUrl, final String teamDomain, final String authToken, final boolean botUser, final String room, final String tokenCredentialId,
                          final String sendAs, final boolean startNotification, final boolean notifyAborted, final boolean notifyFailure,
                          final boolean notifyNotBuilt, final boolean notifySuccess, final boolean notifyUnstable, final boolean notifyRegression, final boolean notifyBackToNormal,


### PR DESCRIPTION
After https://github.com/jenkinsci/slack-plugin/commit/129db5947201ca1730c02d7c42e5f7c6b352868a (#452)
You couldn't save any settings of the plugin inside a job, it kept resetting back to default

This patch restores the saving ability

Closes:  #460