### PR TITLE
Always runAfterFinalized

### DIFF
--- a/src/main/java/jenkins/plugins/slack/SlackNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/SlackNotifier.java
@@ -425,7 +425,7 @@ public class SlackNotifier extends Notifier {
 
     @Override
     public boolean needsToRunAfterFinalized() {
-        return notifyRegression;
+        return true;
     }
 
     @Override


### PR DESCRIPTION
Without this, Notifier#perform runs the Slack message publish code too early,
resulting in messages like this:
```
test - #68 Success after 6.9 sec and counting (Open)
```
`isBuilding()` should be true in this instance.

Instead, always run the plugin with `runAfterFinalised=true.`
This restores the older behavior, (before #361, #125) where SlackListener run
the publish code after `isBuilding()` was false and the end message was:
```
test - #80 Success after 6 sec (Open)
```

Refers: #446 (maybe #454) #455 #457