### PR TITLE
Adding null check on custom message

### DIFF
--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -460,7 +460,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
                     customMessage = notifier.getCustomMessageFailure();
                 }
             }
-            if (customMessage.isEmpty()) {
+            if (customMessage == null || customMessage.isEmpty()) {
                 customMessage = notifier.getCustomMessage();
             }
             try {


### PR DESCRIPTION
When falling back to the default custom message, it would throw an exception if the custom message was null.