### PR TITLE
Allow broadcasting thread messages to the channel 

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,21 @@ node {
 
 This feature requires botUser mode.
 
+Messages that are posted to a thread can also optionally be broadcasted to the
+channel. Set `replyBroadcast: true` to do so. For example:
+
+```
+node {
+    def slackResponse = slackSend(channel: "ci", message: "Started build")
+    slackSend(channel: slackResponse.threadId, message: "Build still in progress")
+    slackSend(
+        channel: slackResponse.threadId,
+        replyBroadcast: true,
+        message: "Build failed. Broadcast to channel for better visibility."
+    )
+}
+```
+
 
 ## Install Instructions for Slack compatible application
 

--- a/src/main/java/jenkins/plugins/slack/StandardSlackService.java
+++ b/src/main/java/jenkins/plugins/slack/StandardSlackService.java
@@ -53,9 +53,14 @@ public class StandardSlackService implements SlackService {
     private String authTokenCredentialId;
     private boolean botUser;
     private String[] roomIds;
+    private boolean replyBroadcast;
     private String responseString = null;
 
     public StandardSlackService(String baseUrl, String teamDomain, String token, String authTokenCredentialId, boolean botUser, String roomId) {
+        this(baseUrl, teamDomain, token, authTokenCredentialId, botUser, roomId, false);
+    }
+
+    public StandardSlackService(String baseUrl, String teamDomain, String token, String authTokenCredentialId, boolean botUser, String roomId, boolean replyBroadcast) {
         super();
         this.baseUrl = baseUrl;
         if(this.baseUrl != null && !this.baseUrl.isEmpty() && !this.baseUrl.endsWith("/")) {
@@ -66,6 +71,7 @@ public class StandardSlackService implements SlackService {
         this.authTokenCredentialId = StringUtils.trim(authTokenCredentialId);
         this.botUser = botUser;
         this.roomIds = roomId.split("[,; ]+");
+        this.replyBroadcast = replyBroadcast;
     }
 
     public String getResponseString() {
@@ -140,6 +146,9 @@ public class StandardSlackService implements SlackService {
                         "&as_user=true";
                 if (threadTs.length() > 1) {
                     url += "&thread_ts=" + threadTs;
+                }
+                if (replyBroadcast) {
+                    url += "&reply_broadcast=true";
                 }
                 try {
                     url += "&attachments=" + URLEncoder.encode(attachments.toString(), "utf-8");

--- a/src/main/java/jenkins/plugins/slack/workflow/SlackSendStep.java
+++ b/src/main/java/jenkins/plugins/slack/workflow/SlackSendStep.java
@@ -233,7 +233,7 @@ public class SlackSendStep extends AbstractStepImpl {
             listener.getLogger().println(Messages
                     .SlackSendStepConfig(step.baseUrl == null, step.teamDomain == null, step.token == null, step.channel == null, step.color == null));
 
-            SlackService slackService = getSlackService(baseUrl, team, token, tokenCredentialId, botUser, channel);
+            SlackService slackService = getSlackService(baseUrl, team, token, tokenCredentialId, botUser, channel, false);
             boolean publishSuccess;
             if (step.attachments != null) {
                 JsonSlurper jsonSlurper = new JsonSlurper();
@@ -291,8 +291,8 @@ public class SlackSendStep extends AbstractStepImpl {
         }
 
         //streamline unit testing
-        SlackService getSlackService(String baseUrl, String team, String token, String tokenCredentialId, boolean botUser, String channel) {
-            return new StandardSlackService(baseUrl, team, token, tokenCredentialId, botUser, channel);
+        SlackService getSlackService(String baseUrl, String team, String token, String tokenCredentialId, boolean botUser, String channel, boolean replyBroadcast) {
+            return new StandardSlackService(baseUrl, team, token, tokenCredentialId, botUser, channel, replyBroadcast);
         }
     }
 }

--- a/src/main/java/jenkins/plugins/slack/workflow/SlackSendStep.java
+++ b/src/main/java/jenkins/plugins/slack/workflow/SlackSendStep.java
@@ -51,6 +51,7 @@ public class SlackSendStep extends AbstractStepImpl {
     private String teamDomain;
     private boolean failOnError;
     private String attachments;
+    private boolean replyBroadcast;
 
 
     @Nonnull
@@ -147,6 +148,15 @@ public class SlackSendStep extends AbstractStepImpl {
         this.message = message;
     }
 
+    public boolean getReplyBroadcast() {
+        return replyBroadcast;
+    }
+
+    @DataBoundSetter
+    public void setReplyBroadcast(boolean replyBroadcast) {
+        this.replyBroadcast = replyBroadcast;
+    }
+
     @DataBoundConstructor
     public SlackSendStep() {
     }
@@ -233,7 +243,7 @@ public class SlackSendStep extends AbstractStepImpl {
             listener.getLogger().println(Messages
                     .SlackSendStepConfig(step.baseUrl == null, step.teamDomain == null, step.token == null, step.channel == null, step.color == null));
 
-            SlackService slackService = getSlackService(baseUrl, team, token, tokenCredentialId, botUser, channel, false);
+            SlackService slackService = getSlackService(baseUrl, team, token, tokenCredentialId, botUser, channel, step.replyBroadcast);
             boolean publishSuccess;
             if (step.attachments != null) {
                 JsonSlurper jsonSlurper = new JsonSlurper();

--- a/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepTest.java
+++ b/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepTest.java
@@ -190,6 +190,35 @@ public class SlackSendStepTest {
     }
 
     @Test
+    public void testReplyBroadcast() throws Exception {
+
+        SlackSendStep.SlackSendStepExecution stepExecution = spy(new SlackSendStep.SlackSendStepExecution());
+        stepExecution.step = new SlackSendStep();
+        stepExecution.step.setMessage("message");
+        stepExecution.step.setReplyBroadcast(true);
+
+        when(Jenkins.getActiveInstance()).thenReturn(jenkins);
+
+        stepExecution.listener = taskListenerMock;
+
+        when(slackDescMock.getBaseUrl()).thenReturn("globalBaseUrl");
+        when(slackDescMock.getTeamDomain()).thenReturn("globalTeamDomain");
+        when(slackDescMock.getToken()).thenReturn("globalToken");
+        when(slackDescMock.getTokenCredentialId()).thenReturn("globalTokenCredentialId");
+        when(slackDescMock.isBotUser()).thenReturn(false);
+        when(slackDescMock.getRoom()).thenReturn("globalChannel");
+
+        when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
+        doNothing().when(printStreamMock).println();
+
+        when(stepExecution.getSlackService(anyString(), anyString(), anyString(), anyString(), anyBoolean(), anyString(), anyBoolean())).thenReturn(slackServiceMock);
+
+        stepExecution.run();
+        verify(stepExecution, times(1)).getSlackService("globalBaseUrl", "globalTeamDomain", "globalToken", "globalTokenCredentialId", false, "globalChannel", true);
+        verify(slackServiceMock, times(1)).publish("message", "");
+    }
+
+    @Test
     public void testNonNullEmptyColor() throws Exception {
 
         SlackSendStep.SlackSendStepExecution stepExecution = spy(new SlackSendStep.SlackSendStepExecution());

--- a/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepTest.java
+++ b/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepTest.java
@@ -83,11 +83,11 @@ public class SlackSendStepTest {
         when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
         doNothing().when(printStreamMock).println();
 
-        when(stepExecution.getSlackService(anyString(), anyString(), anyString(), anyString(), anyBoolean(), anyString())).thenReturn(slackServiceMock);
+        when(stepExecution.getSlackService(anyString(), anyString(), anyString(), anyString(), anyBoolean(), anyString(), anyBoolean())).thenReturn(slackServiceMock);
         when(slackServiceMock.publish(anyString(), anyString())).thenReturn(true);
 
         stepExecution.run();
-        verify(stepExecution, times(1)).getSlackService("baseUrl/", "teamDomain", "token", "tokenCredentialId", false, "channel");
+        verify(stepExecution, times(1)).getSlackService("baseUrl/", "teamDomain", "token", "tokenCredentialId", false, "channel", false);
         verify(slackServiceMock, times(1)).publish("message", "good");
         assertFalse(stepExecution.step.isFailOnError());
     }
@@ -116,11 +116,11 @@ public class SlackSendStepTest {
         when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
         doNothing().when(printStreamMock).println();
 
-        when(stepExecution.getSlackService(anyString(), anyString(), anyString(), anyString(), anyBoolean(), anyString())).thenReturn(slackServiceMock);
+        when(stepExecution.getSlackService(anyString(), anyString(), anyString(), anyString(), anyBoolean(), anyString(), anyBoolean())).thenReturn(slackServiceMock);
         when(slackServiceMock.publish(anyString(), anyString())).thenReturn(true);
 
         stepExecution.run();
-        verify(stepExecution, times(1)).getSlackService("baseUrl/", "teamDomain", "token", "tokenCredentialId", false, "channel");
+        verify(stepExecution, times(1)).getSlackService("baseUrl/", "teamDomain", "token", "tokenCredentialId", false, "channel", false);
         verify(slackServiceMock, times(1)).publish("message", "good");
         assertFalse(stepExecution.step.isFailOnError());
     }
@@ -147,7 +147,7 @@ public class SlackSendStepTest {
         when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
         doNothing().when(printStreamMock).println();
 
-        when(stepExecution.getSlackService(anyString(), anyString(), anyString(), anyString(), anyBoolean(), anyString())).thenReturn(slackServiceMock);
+        when(stepExecution.getSlackService(anyString(), anyString(), anyString(), anyString(), anyBoolean(), anyString(), anyBoolean())).thenReturn(slackServiceMock);
 
         stepExecution.run();
         verify(slackServiceMock, times(0)).publish("message", "");
@@ -176,10 +176,10 @@ public class SlackSendStepTest {
         when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
         doNothing().when(printStreamMock).println();
 
-        when(stepExecution.getSlackService(anyString(), anyString(), anyString(), anyString(), anyBoolean(), anyString())).thenReturn(slackServiceMock);
+        when(stepExecution.getSlackService(anyString(), anyString(), anyString(), anyString(), anyBoolean(), anyString(), anyBoolean())).thenReturn(slackServiceMock);
 
         stepExecution.run();
-        verify(stepExecution, times(1)).getSlackService("globalBaseUrl", "globalTeamDomain", "globalToken", "globalTokenCredentialId", false, "globalChannel");
+        verify(stepExecution, times(1)).getSlackService("globalBaseUrl", "globalTeamDomain", "globalToken", "globalTokenCredentialId", false, "globalChannel", false);
         verify(slackServiceMock, times(1)).publish("message", "");
         assertNull(stepExecution.step.getBaseUrl());
         assertNull(stepExecution.step.getTeamDomain());
@@ -205,7 +205,7 @@ public class SlackSendStepTest {
         when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
         doNothing().when(printStreamMock).println();
 
-        when(stepExecution.getSlackService(anyString(), anyString(), anyString(), anyString(), anyBoolean(), anyString())).thenReturn(slackServiceMock);
+        when(stepExecution.getSlackService(anyString(), anyString(), anyString(), anyString(), anyBoolean(), anyString(), anyBoolean())).thenReturn(slackServiceMock);
 
         stepExecution.run();
         verify(slackServiceMock, times(1)).publish("message", "");
@@ -233,7 +233,7 @@ public class SlackSendStepTest {
         when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
         doNothing().when(printStreamMock).println();
 
-        when(stepExecution.getSlackService(anyString(), anyString(), anyString(), anyString(), anyBoolean(), anyString())).thenReturn(slackServiceMock);
+        when(stepExecution.getSlackService(anyString(), anyString(), anyString(), anyString(), anyBoolean(), anyString(), anyBoolean())).thenReturn(slackServiceMock);
 
         String savedResponse = IOUtils.toString(
                 this.getClass().getResourceAsStream("response.json")
@@ -273,7 +273,7 @@ public class SlackSendStepTest {
         when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
         doNothing().when(printStreamMock).println();
 
-        when(stepExecution.getSlackService(anyString(), anyString(), anyString(), anyString(), anyBoolean(), anyString())).thenReturn(slackServiceMock);
+        when(stepExecution.getSlackService(anyString(), anyString(), anyString(), anyString(), anyBoolean(), anyString(), anyBoolean())).thenReturn(slackServiceMock);
 
         when(slackServiceMock.getResponseString()).thenReturn(null);
         when(slackServiceMock.publish(anyString(), anyString())).thenReturn(true);


### PR DESCRIPTION
This allows posting messages into threads while still broadcasting them to the channel as well. This is useful in case of serious errors or other situations requiring attention.

[Slack documentation][1] says:

> Provide a `thread_ts` value for the posted message to act as a reply to a parent message. Sparingly set `reply_broadcast` to `true` if your reply is important enough for everyone in the channel to receive.

[1]: https://api.slack.com/methods/chat.postMessage#threads_and_replies