### PR TITLE
Remove token botUser hack

### DIFF
--- a/src/main/java/jenkins/plugins/slack/SlackNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/SlackNotifier.java
@@ -401,13 +401,15 @@ public class SlackNotifier extends Notifier {
     }
 
     public SlackService newSlackService(AbstractBuild r, BuildListener listener) {
-        String teamDomain = Util.fixEmpty(this.teamDomain) != null ? this.teamDomain : getDescriptor().getTeamDomain();
-        String baseUrl = Util.fixEmpty(this.baseUrl) != null ? this.baseUrl : getDescriptor().getBaseUrl();
-        String authToken = Util.fixEmpty(this.authToken) != null ? this.authToken : getDescriptor().getToken();
-        boolean botUser = this.botUser != null ? this.botUser : getDescriptor().isBotUser();
+        DescriptorImpl descriptor = getDescriptor();
+        String teamDomain = Util.fixEmpty(this.teamDomain) != null ? this.teamDomain : descriptor.getTeamDomain();
+        String baseUrl = Util.fixEmpty(this.baseUrl) != null ? this.baseUrl : descriptor.getBaseUrl();
+        String authToken = Util.fixEmpty(this.authToken) != null ? this.authToken : descriptor.getToken();
+        boolean botUser = this.botUser != null ? this.botUser :
+                descriptor.isBotUser() != null ?  descriptor.isBotUser() : false;
         String authTokenCredentialId = Util.fixEmpty(this.tokenCredentialId) != null ? this.tokenCredentialId :
-                getDescriptor().getTokenCredentialId();
-        String room = Util.fixEmpty(this.room) != null ? this.room : getDescriptor().getRoom();
+                descriptor.getTokenCredentialId();
+        String room = Util.fixEmpty(this.room) != null ? this.room : descriptor.getRoom();
 
         EnvVars env;
         try {

--- a/src/main/java/jenkins/plugins/slack/SlackNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/SlackNotifier.java
@@ -5,6 +5,7 @@ import com.cloudbees.plugins.credentials.domains.HostnameRequirement;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Launcher;
+import hudson.Util;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
@@ -46,7 +47,7 @@ public class SlackNotifier extends Notifier {
     private String teamDomain;
     private String authToken;
     private String tokenCredentialId;
-    private boolean botUser;
+    private Boolean botUser;
     private String room;
     private String sendAs;
     private boolean startNotification;
@@ -400,30 +401,13 @@ public class SlackNotifier extends Notifier {
     }
 
     public SlackService newSlackService(AbstractBuild r, BuildListener listener) {
-        String teamDomain = this.teamDomain;
-        if (StringUtils.isEmpty(teamDomain)) {
-            teamDomain = getDescriptor().getTeamDomain();
-        }
-
-        String baseUrl = this.baseUrl;
-        if (StringUtils.isEmpty(baseUrl)) {
-            baseUrl = getDescriptor().getBaseUrl();
-        }
-
-        String authToken = this.authToken;
-        if (StringUtils.isEmpty(authToken)) {
-            authToken = getDescriptor().getToken();
-            botUser = getDescriptor().isBotUser();
-        }
-        String authTokenCredentialId = this.tokenCredentialId;
-
-        if (StringUtils.isEmpty(authTokenCredentialId)) {
-            authTokenCredentialId = getDescriptor().getTokenCredentialId();
-        }
-        String room = this.room;
-        if (StringUtils.isEmpty(room)) {
-            room = getDescriptor().getRoom();
-        }
+        String teamDomain = Util.fixEmpty(this.teamDomain) != null ? this.teamDomain : getDescriptor().getTeamDomain();
+        String baseUrl = Util.fixEmpty(this.baseUrl) != null ? this.baseUrl : getDescriptor().getBaseUrl();
+        String authToken = Util.fixEmpty(this.authToken) != null ? this.authToken : getDescriptor().getToken();
+        boolean botUser = this.botUser != null ? this.botUser : getDescriptor().isBotUser();
+        String authTokenCredentialId = Util.fixEmpty(this.tokenCredentialId) != null ? this.tokenCredentialId :
+                getDescriptor().getTokenCredentialId();
+        String room = Util.fixEmpty(this.room) != null ? this.room : getDescriptor().getRoom();
 
         EnvVars env;
         try {
@@ -473,7 +457,7 @@ public class SlackNotifier extends Notifier {
         private String teamDomain;
         private String token;
         private String tokenCredentialId;
-        private boolean botUser;
+        private Boolean botUser;
         private String room;
         private String sendAs;
 
@@ -517,7 +501,7 @@ public class SlackNotifier extends Notifier {
             this.tokenCredentialId = tokenCredentialId;
         }
 
-        public boolean isBotUser() {
+        public Boolean isBotUser() {
             return botUser;
         }
 

--- a/src/main/java/jenkins/plugins/slack/SlackNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/SlackNotifier.java
@@ -48,7 +48,7 @@ public class SlackNotifier extends Notifier {
     private String teamDomain;
     private String authToken;
     private String tokenCredentialId;
-    private Boolean botUser;
+    private boolean botUser;
     private String room;
     private String sendAs;
     private boolean startNotification;
@@ -406,8 +406,7 @@ public class SlackNotifier extends Notifier {
         String teamDomain = Util.fixEmpty(this.teamDomain) != null ? this.teamDomain : descriptor.getTeamDomain();
         String baseUrl = Util.fixEmpty(this.baseUrl) != null ? this.baseUrl : descriptor.getBaseUrl();
         String authToken = Util.fixEmpty(this.authToken) != null ? this.authToken : descriptor.getToken();
-        boolean botUser = this.botUser != null ? this.botUser :
-                descriptor.isBotUser() != null ?  descriptor.isBotUser() : false;
+        boolean botUser = this.botUser || descriptor.isBotUser();
         String authTokenCredentialId = Util.fixEmpty(this.tokenCredentialId) != null ? this.tokenCredentialId :
                 descriptor.getTokenCredentialId();
         String room = Util.fixEmpty(this.room) != null ? this.room : descriptor.getRoom();
@@ -460,7 +459,7 @@ public class SlackNotifier extends Notifier {
         private String teamDomain;
         private String token;
         private String tokenCredentialId;
-        private Boolean botUser;
+        private boolean botUser;
         private String room;
         private String sendAs;
 
@@ -504,7 +503,7 @@ public class SlackNotifier extends Notifier {
             this.tokenCredentialId = tokenCredentialId;
         }
 
-        public Boolean isBotUser() {
+        public boolean isBotUser() {
             return botUser;
         }
 
@@ -595,7 +594,7 @@ public class SlackNotifier extends Notifier {
                                                @QueryParameter("teamDomain") final String teamDomain,
                                                @QueryParameter("token") final String authToken,
                                                @QueryParameter("tokenCredentialId") final String tokenCredentialId,
-                                               @QueryParameter("botUser") final Boolean botUser,
+                                               @QueryParameter("botUser") final boolean botUser,
                                                @QueryParameter("room") final String room) {
 
             try {
@@ -610,7 +609,7 @@ public class SlackNotifier extends Notifier {
                 }
                 String targetDomain = Util.fixEmpty(teamDomain) != null ? teamDomain : this.teamDomain;
                 String targetToken = Util.fixEmpty(authToken) != null ? authToken : this.token;
-                boolean targetBotUser = botUser != null ? botUser : this.botUser != null ? this.botUser : false;
+                boolean targetBotUser = botUser ? botUser : this.botUser;
                 String targetTokenCredentialId = Util.fixEmpty(tokenCredentialId) != null ? tokenCredentialId :
                         this.tokenCredentialId;
                 String targetRoom = Util.fixEmpty(room) != null ? room : this.room;

--- a/src/main/java/jenkins/plugins/slack/workflow/SlackSendStep.java
+++ b/src/main/java/jenkins/plugins/slack/workflow/SlackSendStep.java
@@ -45,7 +45,7 @@ public class SlackSendStep extends AbstractStepImpl {
     private String color;
     private String token;
     private String tokenCredentialId;
-    private boolean botUser;
+    private Boolean botUser;
     private String channel;
     private String baseUrl;
     private String teamDomain;
@@ -86,12 +86,12 @@ public class SlackSendStep extends AbstractStepImpl {
         this.tokenCredentialId = Util.fixEmpty(tokenCredentialId);
     }
 
-    public boolean getBotUser() {
+    public Boolean getBotUser() {
         return botUser;
     }
 
     @DataBoundSetter
-    public void setBotUser(boolean botUser) {
+    public void setBotUser(Boolean botUser) {
         this.botUser = botUser;
     }
 
@@ -221,29 +221,24 @@ public class SlackSendStep extends AbstractStepImpl {
             Jenkins jenkins = Jenkins.getActiveInstance();
 
             SlackNotifier.DescriptorImpl slackDesc = jenkins.getDescriptorByType(SlackNotifier.DescriptorImpl.class);
-            listener.getLogger().println("run slackstepsend, step " + step.botUser + ", desc " + slackDesc.isBotUser());
 
             String baseUrl = step.baseUrl != null ? step.baseUrl : slackDesc.getBaseUrl();
-            String team = step.teamDomain != null ? step.teamDomain : slackDesc.getTeamDomain();
+            String teamDomain = step.teamDomain != null ? step.teamDomain : slackDesc.getTeamDomain();
             String tokenCredentialId = step.tokenCredentialId != null ? step.tokenCredentialId : slackDesc
                     .getTokenCredentialId();
-            String token;
-            boolean botUser;
-            if (step.token != null) {
-                token = step.token;
-                botUser = step.botUser;
-            } else {
-                token = slackDesc.getToken();
-                botUser = slackDesc.isBotUser();
-            }
+            String token = step.token != null ? step.token : slackDesc.getToken();
+            boolean botUser = step.botUser != null ? step.botUser : slackDesc.isBotUser();
             String channel = step.channel != null ? step.channel : slackDesc.getRoom();
             String color = step.color != null ? step.color : "";
 
-            //placing in console log to simplify testing of retrieving values from global config or from step field; also used for tests
-            listener.getLogger().println(Messages
-                    .SlackSendStepConfig(step.baseUrl == null, step.teamDomain == null, step.token == null, step.channel == null, step.color == null));
+            listener.getLogger().println(Messages.SlackSendStepValues(
+                    defaultIfEmpty(baseUrl), defaultIfEmpty(teamDomain), channel, defaultIfEmpty(color), botUser,
+                    defaultIfEmpty(tokenCredentialId))
+            );
 
-            SlackService slackService = getSlackService(baseUrl, team, token, tokenCredentialId, botUser, channel, step.replyBroadcast);
+            SlackService slackService = getSlackService(
+                    baseUrl, teamDomain, token, tokenCredentialId, botUser, channel, step.replyBroadcast
+            );
             boolean publishSuccess;
             if (step.attachments != null) {
                 JsonSlurper jsonSlurper = new JsonSlurper();
@@ -298,6 +293,10 @@ public class SlackSendStep extends AbstractStepImpl {
                 listener.error(Messages.NotificationFailed());
             }
             return response;
+        }
+
+        private String defaultIfEmpty(String value) {
+            return Util.fixEmpty(value) != null ? value : Messages.SlackSendStepValuesEmptyMessage();
         }
 
         //streamline unit testing

--- a/src/main/java/jenkins/plugins/slack/workflow/SlackSendStep.java
+++ b/src/main/java/jenkins/plugins/slack/workflow/SlackSendStep.java
@@ -45,7 +45,7 @@ public class SlackSendStep extends AbstractStepImpl {
     private String color;
     private String token;
     private String tokenCredentialId;
-    private Boolean botUser;
+    private boolean botUser;
     private String channel;
     private String baseUrl;
     private String teamDomain;
@@ -86,12 +86,12 @@ public class SlackSendStep extends AbstractStepImpl {
         this.tokenCredentialId = Util.fixEmpty(tokenCredentialId);
     }
 
-    public Boolean getBotUser() {
+    public boolean getBotUser() {
         return botUser;
     }
 
     @DataBoundSetter
-    public void setBotUser(Boolean botUser) {
+    public void setBotUser(boolean botUser) {
         this.botUser = botUser;
     }
 
@@ -227,7 +227,7 @@ public class SlackSendStep extends AbstractStepImpl {
             String tokenCredentialId = step.tokenCredentialId != null ? step.tokenCredentialId : slackDesc
                     .getTokenCredentialId();
             String token = step.token != null ? step.token : slackDesc.getToken();
-            boolean botUser = getBotUser(slackDesc);
+            boolean botUser = step.botUser || slackDesc.isBotUser();
             String channel = step.channel != null ? step.channel : slackDesc.getRoom();
             String color = step.color != null ? step.color : "";
 
@@ -293,10 +293,6 @@ public class SlackSendStep extends AbstractStepImpl {
                 listener.error(Messages.NotificationFailed());
             }
             return response;
-        }
-
-        private boolean getBotUser(SlackNotifier.DescriptorImpl slackDesc) {
-            return step.botUser != null ? step.botUser : slackDesc.isBotUser() != null ? slackDesc.isBotUser() : false;
         }
 
         private String defaultIfEmpty(String value) {

--- a/src/main/java/jenkins/plugins/slack/workflow/SlackSendStep.java
+++ b/src/main/java/jenkins/plugins/slack/workflow/SlackSendStep.java
@@ -227,7 +227,7 @@ public class SlackSendStep extends AbstractStepImpl {
             String tokenCredentialId = step.tokenCredentialId != null ? step.tokenCredentialId : slackDesc
                     .getTokenCredentialId();
             String token = step.token != null ? step.token : slackDesc.getToken();
-            boolean botUser = step.botUser != null ? step.botUser : slackDesc.isBotUser();
+            boolean botUser = getBotUser(slackDesc);
             String channel = step.channel != null ? step.channel : slackDesc.getRoom();
             String color = step.color != null ? step.color : "";
 
@@ -293,6 +293,10 @@ public class SlackSendStep extends AbstractStepImpl {
                 listener.error(Messages.NotificationFailed());
             }
             return response;
+        }
+
+        private boolean getBotUser(SlackNotifier.DescriptorImpl slackDesc) {
+            return step.botUser != null ? step.botUser : slackDesc.isBotUser() != null ? slackDesc.isBotUser() : false;
         }
 
         private String defaultIfEmpty(String value) {

--- a/src/main/resources/jenkins/plugins/slack/Messages.properties
+++ b/src/main/resources/jenkins/plugins/slack/Messages.properties
@@ -4,6 +4,6 @@ SlackSendStepDisplayName=Send Slack Message
 # Messages to display in the build logs
 NotificationFailed=Slack notification failed. See Jenkins logs for details.
 NotificationFailedWithException=Slack notification failed with exception: {0}
-SlackSendStepValues=Slack Send Pipeline step running, values are - baseUrl: {0}, teamDomain: {1}, channel: {2}, color: {3}, botUser: {4}, tokenCredentialId: {5} 
+SlackSendStepValues=Slack Send Pipeline step running, values are - baseUrl: {0}, teamDomain: {1}, channel: {2}, color: {3}, botUser: {4}, tokenCredentialId: {5}
 SlackSendStepValuesEmptyMessage=<empty>
 FailedToParseSlackResponse=Could not parse response from slack, potentially because of invalid configuration (botUser: true and baseUrl set)

--- a/src/main/resources/jenkins/plugins/slack/Messages.properties
+++ b/src/main/resources/jenkins/plugins/slack/Messages.properties
@@ -4,5 +4,6 @@ SlackSendStepDisplayName=Send Slack Message
 # Messages to display in the build logs
 NotificationFailed=Slack notification failed. See Jenkins logs for details.
 NotificationFailedWithException=Slack notification failed with exception: {0}
-SlackSendStepConfig=Slack Send Pipeline step configured values from global config - baseUrl: {0}, teamDomain: {1}, token: {2}, channel: {3}, color: {4}
+SlackSendStepValues=Slack Send Pipeline step running, values are - baseUrl: {0}, teamDomain: {1}, channel: {2}, color: {3}, botUser: {4}, tokenCredentialId: {5} 
+SlackSendStepValuesEmptyMessage=<empty>
 FailedToParseSlackResponse=Could not parse response from slack, potentially because of invalid configuration (botUser: true and baseUrl set)

--- a/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepIntegrationTest.java
+++ b/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepIntegrationTest.java
@@ -37,7 +37,7 @@ public class SlackSendStepIntegrationTest {
         job.setDefinition(new CpsFlowDefinition("slackSend(message: 'message', baseUrl: 'baseUrl', teamDomain: 'teamDomain', token: 'token', tokenCredentialId: 'tokenCredentialId', channel: '#channel', color: 'good');", true));
         WorkflowRun run = jenkinsRule.assertBuildStatusSuccess(job.scheduleBuild2(0).get());
         //everything should come from step configuration
-        jenkinsRule.assertLogContains(Messages.SlackSendStepConfig(false, false, false, false, false), run);
+        jenkinsRule.assertLogContains(Messages.SlackSendStepValues("baseUrl/", "teamDomain", "#channel", "good", false, "tokenCredentialId"), run);
     }
 
     @Test

--- a/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepTest.java
+++ b/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepTest.java
@@ -66,7 +66,7 @@ public class SlackSendStepTest {
         slackSendStep.setMessage("message");
         slackSendStep.setToken("token");
         slackSendStep.setTokenCredentialId("tokenCredentialId");
-        slackSendStep.setBotUser(false);
+        slackSendStep.setBotUser(true);
         slackSendStep.setBaseUrl("baseUrl/");
         slackSendStep.setTeamDomain("teamDomain");
         slackSendStep.setChannel("channel");
@@ -78,7 +78,7 @@ public class SlackSendStepTest {
         stepExecution.listener = taskListenerMock;
 
         when(slackDescMock.getToken()).thenReturn("differentToken");
-        when(slackDescMock.isBotUser()).thenReturn(true);
+        when(slackDescMock.isBotUser()).thenReturn(false);
 
         when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
         doNothing().when(printStreamMock).println();
@@ -87,40 +87,7 @@ public class SlackSendStepTest {
         when(slackServiceMock.publish(anyString(), anyString())).thenReturn(true);
 
         stepExecution.run();
-        verify(stepExecution, times(1)).getSlackService("baseUrl/", "teamDomain", "token", "tokenCredentialId", false, "channel", false);
-        verify(slackServiceMock, times(1)).publish("message", "good");
-        assertFalse(stepExecution.step.isFailOnError());
-    }
-
-    @Test
-    public void testStepOverrides2() throws Exception {
-        SlackSendStep.SlackSendStepExecution stepExecution = spy(new SlackSendStep.SlackSendStepExecution());
-        SlackSendStep slackSendStep = new SlackSendStep();
-        slackSendStep.setMessage("message");
-        slackSendStep.setToken("token");
-        slackSendStep.setTokenCredentialId("tokenCredentialId");
-        slackSendStep.setBotUser(false);
-        slackSendStep.setBaseUrl("baseUrl");
-        slackSendStep.setTeamDomain("teamDomain");
-        slackSendStep.setChannel("channel");
-        slackSendStep.setColor("good");
-        stepExecution.step = slackSendStep;
-
-        when(Jenkins.getActiveInstance()).thenReturn(jenkins);
-
-        stepExecution.listener = taskListenerMock;
-
-        when(slackDescMock.getToken()).thenReturn("differentToken");
-        when(slackDescMock.isBotUser()).thenReturn(true);
-
-        when(taskListenerMock.getLogger()).thenReturn(printStreamMock);
-        doNothing().when(printStreamMock).println();
-
-        when(stepExecution.getSlackService(anyString(), anyString(), anyString(), anyString(), anyBoolean(), anyString(), anyBoolean())).thenReturn(slackServiceMock);
-        when(slackServiceMock.publish(anyString(), anyString())).thenReturn(true);
-
-        stepExecution.run();
-        verify(stepExecution, times(1)).getSlackService("baseUrl/", "teamDomain", "token", "tokenCredentialId", false, "channel", false);
+        verify(stepExecution, times(1)).getSlackService("baseUrl/", "teamDomain", "token", "tokenCredentialId", true, "channel", false);
         verify(slackServiceMock, times(1)).publish("message", "good");
         assertFalse(stepExecution.step.isFailOnError());
     }


### PR DESCRIPTION
In preparation for removing the direct token support, I noticed that botUser is loaded conditionally from the global config if token is null, I assume this was previously overriding anyones job or step config if they set bot user to be something different to global and used credentials.

I think a more complete fix might be to create a slack credential type and then have the bot user on the credential, but that's a more involved changed and requires migration, more testing and some thought

The current fix will prevent setting it to false at the job level, functionality that is probably not needed and is pretty similar to what was there before but not gated with the is token set hack

Also:
Cleaned up logging, removed mostly wrong global config logging in
slackSend, replaced with values that are safe to go into the log.

Code simplification for getting config or descriptor