### PR TITLE
Bump baseline and parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.25</version>
+        <version>3.33</version>
     </parent>
 
     <artifactId>slack</artifactId>
@@ -16,7 +16,7 @@
     <url>http://wiki.jenkins-ci.org/display/JENKINS/Slack+Plugin</url>
 
     <properties>
-        <jenkins.version>2.60.3</jenkins.version>
+        <jenkins.version>2.138.1</jenkins.version>
         <revision>2.4</revision>
         <changelist>-SNAPSHOT</changelist>
         <java.level>8</java.level>


### PR DESCRIPTION
Based on http://stats.jenkins.io/pluginversions/slack.html
96% of users are using this version of jenkins or higher

Lets increase the baseline to reduce the amount of jenkins versions issues could be caused by, and to allow some modernisation of code