### PR TITLE
Add minimumJavaVersion config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,7 @@
                 <artifactId>maven-hpi-plugin</artifactId>
                 <configuration>
                     <compatibleSinceVersion>2.0</compatibleSinceVersion>
+                    <minimumJavaVersion>1.8</minimumJavaVersion>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
It's marked as required in the new plugin pom version...
Only required if you override configuration otherwise the config there will be picked up