### PR TITLE
Switch from entry to optional block

### DIFF
--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/global.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/global.jelly
@@ -22,9 +22,7 @@
     <f:entry title="Integration Token Credential ID" field="tokenCredentialId" help="/plugin/slack/help-globalConfig-tokenCredentialId.html">
         <c:select/>
     </f:entry>
-    <f:entry title="Is Bot User?" help="/plugin/slack/help-globalConfig-botUser.html">
-        <f:checkbox field="botUser" />
-    </f:entry>
+    <f:optionalBlock field="botUser" title="Is Bot User" help="/plugin/slack/help-globalConfig-botUser.html" />
     <f:entry title="Channel or Slack ID" help="/plugin/slack/help-globalConfig-slackRoom.html">
         <f:textbox field="room" />
     </f:entry>


### PR DESCRIPTION
See https://issues.jenkins-ci.org/browse/JENKINS-55787

This is the preferred style:
![image](https://user-images.githubusercontent.com/2119212/51774426-47af6f00-20c0-11e9-8f58-ce82bd17dee4.png)
As opposed to:
![image](https://user-images.githubusercontent.com/2119212/51774439-539b3100-20c0-11e9-9c96-6569a173d80c.png)
or 
![image](https://user-images.githubusercontent.com/2119212/51774473-6f9ed280-20c0-11e9-922c-42ea7ddedd34.png)