### PR TITLE
Add null check to extractReplaceLinks

### DIFF
--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -520,15 +520,18 @@ public class ActiveNotifier implements FineGrainedNotifier {
             int size = 0;
             List<String> links = new ArrayList<>();
             while (aTag.find()) {
-                Matcher url = href.matcher(aTag.group(1));
-                if (url.find()) {
-                    String escapeThis = aTag.group(3);
-                    if (escapeThis != null) {
-                        aTag.appendReplacement(sb,String.format("{%s}", size++));
-                        links.add("{");
-                    } else {
-                        aTag.appendReplacement(sb,String.format("{%s}", size++));
-                        links.add(String.format("<%s|%s>", url.group(1).replaceAll("\"", ""), aTag.group(2)));
+                String firstGroup = aTag.group(1);
+                if (firstGroup != null) {
+                    Matcher url = href.matcher(firstGroup);
+                    if (url.find()) {
+                        String escapeThis = aTag.group(3);
+                        if (escapeThis != null) {
+                            aTag.appendReplacement(sb, String.format("{%s}", size++));
+                            links.add("{");
+                        } else {
+                            aTag.appendReplacement(sb, String.format("{%s}", size++));
+                            links.add(String.format("<%s|%s>", url.group(1).replaceAll("\"", ""), aTag.group(2)));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
No real idea what this code does but judging from the stacktrace in the linked issue this is what is null and affecting some people (not many though).
The javadoc says that `.group` can return null

Fixes https://github.com/jenkinsci/slack-plugin/issues/479
Fixes #498

@xUrko @josb I'll merge this towards the next release, it should stop the failure but will need feedback from you guys on what it looks like, as whatever is causing this is still happening so it may need some more code to handle it properly