### PR TITLE
[JENKINS-55787] Switch labels from entry to checkbox

### DIFF
--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/global.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/global.jelly
@@ -22,8 +22,8 @@
     <f:entry title="Integration Token Credential ID" field="tokenCredentialId" help="/plugin/slack/help-globalConfig-tokenCredentialId.html">
         <c:select/>
     </f:entry>
-    <f:entry title="Is Bot User?" help="/plugin/slack/help-globalConfig-botUser.html">
-        <f:checkbox field="botUser" />
+    <f:entry>
+        <f:checkbox field="botUser" title="Is Bot User" help="/plugin/slack/help-globalConfig-botUser.html" />
     </f:entry>
     <f:entry title="Channel or Slack ID" help="/plugin/slack/help-globalConfig-slackRoom.html">
         <f:textbox field="room" />


### PR DESCRIPTION
Sorry, turns out that data migration doesn't like what I did in #494

[https://issues.jenkins-ci.org/browse/JENKINS-55787](https://issues.jenkins-ci.org/browse/JENKINS-55787)

Basically checkboxes should have labels, splitting the labels away from their checkboxes is poor UX, poor accessibility. This change brings the layout more inline with how normal settings UIs lay out checkboxes.