### PR TITLE
Add additional logging for notification conditions

### DIFF
--- a/src/main/java/jenkins/plugins/slack/JenkinsTokenExpander.java
+++ b/src/main/java/jenkins/plugins/slack/JenkinsTokenExpander.java
@@ -1,0 +1,29 @@
+package jenkins.plugins.slack;
+
+import hudson.model.AbstractBuild;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
+import org.jenkinsci.plugins.tokenmacro.TokenMacro;
+
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class JenkinsTokenExpander implements TokenExpander {
+    private static final Logger logger = Logger.getLogger(JenkinsTokenExpander.class.getName());
+    private final TaskListener listener;
+
+    public JenkinsTokenExpander(TaskListener listener) {
+        this.listener = listener;
+    }
+
+    @Override
+    public String expand(String template, AbstractBuild<?, ?> build) {
+        try {
+            return TokenMacro.expandAll(build, listener, template, false, null);
+        } catch (MacroEvaluationException | IOException | InterruptedException e) {
+            logger.log(Level.SEVERE, "Failed to process custom message", e);
+            return "[UNPROCESSABLE] " + template;
+        }
+    }
+}

--- a/src/main/java/jenkins/plugins/slack/StandardSlackService.java
+++ b/src/main/java/jenkins/plugins/slack/StandardSlackService.java
@@ -5,6 +5,7 @@ import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import hudson.ProxyConfiguration;
 import hudson.security.ACL;
 import jenkins.model.Jenkins;
+import jenkins.plugins.slack.logging.BuildKey;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
@@ -172,7 +173,7 @@ public class StandardSlackService implements SlackService {
             		 logger.log(Level.WARNING, "Response Code: " + responseCode);
             		 result = false;
                 } else {
-                    logger.info("Posting succeeded");
+                    logger.fine("Posting succeeded");
                 }
             } catch (Exception e) {
                 logger.log(Level.WARNING, "Error posting to Slack", e);

--- a/src/main/java/jenkins/plugins/slack/TokenExpander.java
+++ b/src/main/java/jenkins/plugins/slack/TokenExpander.java
@@ -1,0 +1,7 @@
+package jenkins.plugins.slack;
+
+import hudson.model.AbstractBuild;
+
+public interface TokenExpander {
+    String expand(String template, AbstractBuild<?, ?> build);
+}

--- a/src/main/java/jenkins/plugins/slack/decisions/Condition.java
+++ b/src/main/java/jenkins/plugins/slack/decisions/Condition.java
@@ -1,0 +1,27 @@
+package jenkins.plugins.slack.decisions;
+
+import jenkins.plugins.slack.logging.BuildAwareLogger;
+
+import java.util.function.Predicate;
+
+interface Condition extends Predicate<Context> {
+    boolean isMetBy(Context context);
+    boolean userPreferenceMatches();
+    BuildAwareLogger log();
+
+    @Override
+    default boolean test(Context context) {
+        boolean isMet = isMetBy(context);
+        boolean preferences = userPreferenceMatches();
+        if (isMet) {
+            if (preferences) {
+                log().info(context.currentKey(), "will send " + getClass().getSimpleName() + "Notification because build matches and user preferences allow it");
+            } else {
+                log().debug(context.currentKey(), "will NOT send " + getClass().getSimpleName() + "Notification - build matches but user preferences do not allow it");
+            }
+        } else {
+            log().debug(context.currentKey(), "does not match " + getClass().getSimpleName() + "Notification condition");
+        }
+        return isMet && preferences;
+    }
+}

--- a/src/main/java/jenkins/plugins/slack/decisions/Context.java
+++ b/src/main/java/jenkins/plugins/slack/decisions/Context.java
@@ -1,0 +1,36 @@
+package jenkins.plugins.slack.decisions;
+
+import hudson.model.AbstractBuild;
+import hudson.model.Result;
+import jenkins.plugins.slack.logging.BuildKey;
+
+import javax.annotation.Nullable;
+
+public class Context {
+    private final AbstractBuild<?, ?> current;
+    private final AbstractBuild<?, ?> previous;
+
+    public Context(AbstractBuild<?, ?> current, AbstractBuild<?, ?> previous) {
+        this.current = current;
+        this.previous = previous;
+    }
+
+    public String currentKey() {
+        return BuildKey.format(current);
+    }
+
+    public Result previousResultOrSuccess() {
+        if (previous == null || previous.getResult() == null) {
+            return Result.SUCCESS;
+        }
+        return previous.getResult();
+    }
+
+    @Nullable
+    public Result currentResult() {
+        if (current == null) {
+            return null;
+        }
+        return current.getResult();
+    }
+}

--- a/src/main/java/jenkins/plugins/slack/decisions/NotificationConditions.java
+++ b/src/main/java/jenkins/plugins/slack/decisions/NotificationConditions.java
@@ -1,0 +1,33 @@
+package jenkins.plugins.slack.decisions;
+
+import jenkins.plugins.slack.SlackNotifier;
+import jenkins.plugins.slack.logging.BuildAwareLogger;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+
+public class NotificationConditions implements Predicate<Context> {
+    private final List<Predicate<Context>> conditions;
+
+    public NotificationConditions(List<Predicate<Context>> conditions) {
+        this.conditions = conditions;
+    }
+
+    public static NotificationConditions create(SlackNotifier preferences, BuildAwareLogger log) {
+        return new NotificationConditions(Arrays.asList(
+                new OnAborted(preferences, log),
+                new OnSingleFailure(preferences, log),
+                new OnRepeatedFailure(preferences, log),
+                new OnNotBuilt(preferences, log),
+                new OnBackToNormal(preferences, log),
+                new OnSuccess(preferences, log),
+                new OnUnstable(preferences, log)
+        ));
+    }
+
+    @Override
+    public boolean test(Context context) {
+        return conditions.stream().anyMatch(p -> p.test(context));
+    }
+}

--- a/src/main/java/jenkins/plugins/slack/decisions/OnAborted.java
+++ b/src/main/java/jenkins/plugins/slack/decisions/OnAborted.java
@@ -1,0 +1,30 @@
+package jenkins.plugins.slack.decisions;
+
+import hudson.model.Result;
+import jenkins.plugins.slack.SlackNotifier;
+import jenkins.plugins.slack.logging.BuildAwareLogger;
+
+public class OnAborted implements Condition {
+    private final SlackNotifier preferences;
+    private final BuildAwareLogger log;
+
+    public OnAborted(SlackNotifier preferences, BuildAwareLogger log) {
+        this.preferences = preferences;
+        this.log = log;
+    }
+
+    @Override
+    public boolean isMetBy(Context context) {
+        return context.currentResult() == Result.ABORTED;
+    }
+
+    @Override
+    public boolean userPreferenceMatches() {
+        return preferences.getNotifyAborted();
+    }
+
+    @Override
+    public BuildAwareLogger log() {
+        return log;
+    }
+}

--- a/src/main/java/jenkins/plugins/slack/decisions/OnBackToNormal.java
+++ b/src/main/java/jenkins/plugins/slack/decisions/OnBackToNormal.java
@@ -1,0 +1,32 @@
+package jenkins.plugins.slack.decisions;
+
+import hudson.model.Result;
+import jenkins.plugins.slack.SlackNotifier;
+import jenkins.plugins.slack.logging.BuildAwareLogger;
+
+public class OnBackToNormal implements Condition {
+    private final SlackNotifier preferences;
+    private final BuildAwareLogger log;
+
+    public OnBackToNormal(SlackNotifier preferences, BuildAwareLogger log) {
+        this.preferences = preferences;
+        this.log = log;
+    }
+
+    @Override
+    public boolean isMetBy(Context context) {
+        Result previousResult = context.previousResultOrSuccess();
+        return context.currentResult() == Result.SUCCESS
+                && (previousResult == Result.FAILURE || previousResult == Result.UNSTABLE);
+    }
+
+    @Override
+    public boolean userPreferenceMatches() {
+        return preferences.getNotifyBackToNormal();
+    }
+
+    @Override
+    public BuildAwareLogger log() {
+        return log;
+    }
+}

--- a/src/main/java/jenkins/plugins/slack/decisions/OnNotBuilt.java
+++ b/src/main/java/jenkins/plugins/slack/decisions/OnNotBuilt.java
@@ -1,0 +1,30 @@
+package jenkins.plugins.slack.decisions;
+
+import hudson.model.Result;
+import jenkins.plugins.slack.SlackNotifier;
+import jenkins.plugins.slack.logging.BuildAwareLogger;
+
+public class OnNotBuilt implements Condition {
+    private final SlackNotifier preferences;
+    private final BuildAwareLogger log;
+
+    public OnNotBuilt(SlackNotifier preferences, BuildAwareLogger log) {
+        this.preferences = preferences;
+        this.log = log;
+    }
+
+    @Override
+    public boolean isMetBy(Context context) {
+        return context.currentResult() == Result.NOT_BUILT;
+    }
+
+    @Override
+    public boolean userPreferenceMatches() {
+        return preferences.getNotifyNotBuilt();
+    }
+
+    @Override
+    public BuildAwareLogger log() {
+        return log;
+    }
+}

--- a/src/main/java/jenkins/plugins/slack/decisions/OnRepeatedFailure.java
+++ b/src/main/java/jenkins/plugins/slack/decisions/OnRepeatedFailure.java
@@ -1,0 +1,31 @@
+package jenkins.plugins.slack.decisions;
+
+import hudson.model.Result;
+import jenkins.plugins.slack.SlackNotifier;
+import jenkins.plugins.slack.logging.BuildAwareLogger;
+
+public class OnRepeatedFailure implements Condition {
+    private final SlackNotifier preferences;
+    private final BuildAwareLogger log;
+
+    public OnRepeatedFailure(SlackNotifier preferences, BuildAwareLogger log) {
+        this.preferences = preferences;
+        this.log = log;
+    }
+
+    @Override
+    public boolean isMetBy(Context context) {
+        return context.currentResult() == Result.FAILURE //notify only on repeated failures
+                && context.previousResultOrSuccess() == Result.FAILURE;
+    }
+
+    @Override
+    public boolean userPreferenceMatches() {
+        return preferences.getNotifyRepeatedFailure();
+    }
+
+    @Override
+    public BuildAwareLogger log() {
+        return log;
+    }
+}

--- a/src/main/java/jenkins/plugins/slack/decisions/OnSingleFailure.java
+++ b/src/main/java/jenkins/plugins/slack/decisions/OnSingleFailure.java
@@ -1,0 +1,31 @@
+package jenkins.plugins.slack.decisions;
+
+import hudson.model.Result;
+import jenkins.plugins.slack.SlackNotifier;
+import jenkins.plugins.slack.logging.BuildAwareLogger;
+
+public class OnSingleFailure implements Condition {
+    private final SlackNotifier preferences;
+    private final BuildAwareLogger log;
+
+    public OnSingleFailure(SlackNotifier preferences, BuildAwareLogger log) {
+        this.preferences = preferences;
+        this.log = log;
+    }
+
+    @Override
+    public boolean isMetBy(Context context) {
+        return context.currentResult() == Result.FAILURE //notify only on single failed build
+                && context.previousResultOrSuccess() != Result.FAILURE;
+    }
+
+    @Override
+    public boolean userPreferenceMatches() {
+        return preferences.getNotifyFailure();
+    }
+
+    @Override
+    public BuildAwareLogger log() {
+        return log;
+    }
+}

--- a/src/main/java/jenkins/plugins/slack/decisions/OnSuccess.java
+++ b/src/main/java/jenkins/plugins/slack/decisions/OnSuccess.java
@@ -1,0 +1,30 @@
+package jenkins.plugins.slack.decisions;
+
+import hudson.model.Result;
+import jenkins.plugins.slack.SlackNotifier;
+import jenkins.plugins.slack.logging.BuildAwareLogger;
+
+public class OnSuccess implements Condition {
+    private final SlackNotifier preferences;
+    private final BuildAwareLogger log;
+
+    public OnSuccess(SlackNotifier preferences, BuildAwareLogger log) {
+        this.preferences = preferences;
+        this.log = log;
+    }
+
+    @Override
+    public boolean isMetBy(Context context) {
+        return context.currentResult() == Result.SUCCESS;
+    }
+
+    @Override
+    public boolean userPreferenceMatches() {
+        return preferences.getNotifySuccess();
+    }
+
+    @Override
+    public BuildAwareLogger log() {
+        return log;
+    }
+}

--- a/src/main/java/jenkins/plugins/slack/decisions/OnUnstable.java
+++ b/src/main/java/jenkins/plugins/slack/decisions/OnUnstable.java
@@ -1,0 +1,30 @@
+package jenkins.plugins.slack.decisions;
+
+import hudson.model.Result;
+import jenkins.plugins.slack.SlackNotifier;
+import jenkins.plugins.slack.logging.BuildAwareLogger;
+
+public class OnUnstable implements Condition {
+    private final SlackNotifier preferences;
+    private final BuildAwareLogger log;
+
+    public OnUnstable(SlackNotifier preferences, BuildAwareLogger log) {
+        this.preferences = preferences;
+        this.log = log;
+    }
+
+    @Override
+    public boolean isMetBy(Context context) {
+        return context.currentResult() == Result.UNSTABLE;
+    }
+
+    @Override
+    public boolean userPreferenceMatches() {
+        return preferences.getNotifyUnstable();
+    }
+
+    @Override
+    public BuildAwareLogger log() {
+        return log;
+    }
+}

--- a/src/main/java/jenkins/plugins/slack/logging/BuildAwareLogger.java
+++ b/src/main/java/jenkins/plugins/slack/logging/BuildAwareLogger.java
@@ -1,0 +1,6 @@
+package jenkins.plugins.slack.logging;
+
+public interface BuildAwareLogger {
+    void debug(String key, String message, Object... args);
+    void info(String key, String message, Object... args);
+}

--- a/src/main/java/jenkins/plugins/slack/logging/BuildKey.java
+++ b/src/main/java/jenkins/plugins/slack/logging/BuildKey.java
@@ -1,0 +1,19 @@
+package jenkins.plugins.slack.logging;
+
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+
+public class BuildKey {
+    private static final String UNKNOWN = "[UNKNOWN BUILD]";
+
+    public static String format(AbstractBuild<?, ?> build) {
+        if (build == null) {
+            return UNKNOWN;
+        }
+        AbstractProject<?, ?> project = build.getProject();
+        if (project == null) {
+            return UNKNOWN;
+        }
+        return "[" + project.getFullDisplayName() + " #" + build.getNumber() + "]";
+    }
+}

--- a/src/main/java/jenkins/plugins/slack/logging/SlackNotificationsLogger.java
+++ b/src/main/java/jenkins/plugins/slack/logging/SlackNotificationsLogger.java
@@ -1,0 +1,50 @@
+package jenkins.plugins.slack.logging;
+
+import hudson.model.AbstractBuild;
+import jenkins.plugins.slack.SlackNotifier;
+
+import java.io.PrintStream;
+import java.util.logging.Logger;
+
+public class SlackNotificationsLogger implements BuildAwareLogger {
+    private static final String PLUGIN_KEY = String.format("[%s]", SlackNotifier.DescriptorImpl.PLUGIN_DISPLAY_NAME);
+    private final Logger system;
+    private final PrintStream user;
+
+    public SlackNotificationsLogger(Logger system, PrintStream user) {
+        this.system = system;
+        this.user = user;
+    }
+
+    /**
+     * Debug logs are only written to the system log.
+     *
+     * @see String#format(String, Object...) for message formatting options
+     * @see BuildKey#format(AbstractBuild) to create a build key easily
+     *
+     * @param key - Human-readable representation of the build
+     * @param message - message to be written to the system log
+     * @param args - arguments for the message
+     */
+    @Override
+    public void debug(String key, String message, Object... args) {
+        system.fine(() -> String.join(" ", key, String.format(message, args)));
+    }
+
+    /**
+     * Info logs are written to the system log with the build key and to the build's log without the key
+     *
+     * @see String#format(String, Object...) for message formatting options
+     * @see BuildKey#format(AbstractBuild) to create a build key easily
+     *
+     * @param key - Human-readable representation of the build
+     * @param message - message to be written to system log and build's console output
+     * @param args - arguments for the message
+     */
+    @Override
+    public void info(String key, String message, Object... args) {
+        String formattedMessage = String.format(message, args);
+        system.info(() -> String.join(" ", key, formattedMessage));
+        user.println(String.join(" ", PLUGIN_KEY, formattedMessage));
+    }
+}

--- a/src/test/java/jenkins/plugins/slack/MessageBuilderEscapeTest.java
+++ b/src/test/java/jenkins/plugins/slack/MessageBuilderEscapeTest.java
@@ -3,6 +3,7 @@ package jenkins.plugins.slack;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.ItemGroup;
+import jenkins.plugins.slack.logging.BuildAwareLogger;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -23,6 +24,8 @@ public class MessageBuilderEscapeTest {
         AbstractProject job = mock(AbstractProject.class);
         ItemGroup group = mock(ItemGroup.class);
         SlackNotifier notifier = mock(SlackNotifier.class);
+        BuildAwareLogger logger = mock(BuildAwareLogger.class);
+        TokenExpander tokenExpander = mock(TokenExpander.class);
 
         when(build.getDisplayName()).thenReturn("build");
         when(build.getProject()).thenReturn(project);
@@ -34,7 +37,7 @@ public class MessageBuilderEscapeTest {
         when(job.getFullDisplayName()).thenReturn("job");
         when(project.getFullDisplayName()).thenReturn("project");
 
-        messageBuilder = new ActiveNotifier.MessageBuilder(notifier, build);
+        messageBuilder = new ActiveNotifier.MessageBuilder(notifier, build, logger, tokenExpander);
     }
 
     @Test

--- a/src/test/java/jenkins/plugins/slack/decisions/ContextTest.java
+++ b/src/test/java/jenkins/plugins/slack/decisions/ContextTest.java
@@ -1,0 +1,86 @@
+package jenkins.plugins.slack.decisions;
+
+import hudson.model.AbstractBuild;
+import hudson.model.Result;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.BDDMockito.given;
+
+public class ContextTest {
+    @Mock
+    private AbstractBuild<?, ?> previous;
+    @Mock
+    private AbstractBuild<?, ?> current;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void shouldReturnSuccessIfPreviousBuildNull() {
+        Context context = new Context(current, null);
+        Result expected = Result.SUCCESS;
+
+        Result actual = context.previousResultOrSuccess();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldReturnSuccessIfPreviousResultNull() {
+        given(previous.getResult()).willReturn(null);
+        Context context = new Context(current, previous);
+        Result expected = Result.SUCCESS;
+
+        Result actual = context.previousResultOrSuccess();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldReturnPreviousResultIfPresent() {
+        Result expected = Result.UNSTABLE;
+        given(previous.getResult()).willReturn(expected);
+        Context context = new Context(current, previous);
+
+        Result actual = context.previousResultOrSuccess();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldReturnCurrentResultIfPresent() {
+        Result expected = Result.NOT_BUILT;
+        given(current.getResult()).willReturn(expected);
+        Context context = new Context(current, previous);
+
+        Result actual = context.currentResult();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldReturnNullIfCurrentBuildNull() {
+        Context context = new Context(null, previous);
+
+        Result actual = context.currentResult();
+
+        assertNull(actual);
+    }
+
+    @Test
+    public void shouldReturnNullIfCurrentResultNull() {
+        given(current.getResult()).willReturn(null);
+        Context context = new Context(current, previous);
+
+        Result actual = context.currentResult();
+
+        assertNull(actual);
+    }
+}

--- a/src/test/java/jenkins/plugins/slack/decisions/NotificationConditionsTest.java
+++ b/src/test/java/jenkins/plugins/slack/decisions/NotificationConditionsTest.java
@@ -1,0 +1,23 @@
+package jenkins.plugins.slack.decisions;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertTrue;
+
+public class NotificationConditionsTest {
+
+    @Test
+    public void shouldMatchIfAnyConditionMatches() {
+        NotificationConditions conditions = new NotificationConditions(Arrays.asList(
+                p -> false,
+                p -> false,
+                p -> true
+        ));
+
+        boolean actual = conditions.test(null);
+
+        assertTrue(actual);
+    }
+}

--- a/src/test/java/jenkins/plugins/slack/decisions/OnBackToNormalTest.java
+++ b/src/test/java/jenkins/plugins/slack/decisions/OnBackToNormalTest.java
@@ -1,0 +1,66 @@
+package jenkins.plugins.slack.decisions;
+
+import hudson.model.Result;
+import jenkins.plugins.slack.logging.BuildAwareLogger;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.BDDMockito.given;
+
+public class OnBackToNormalTest {
+    @Mock
+    private Context context;
+    @Mock
+    private BuildAwareLogger log;
+    private OnBackToNormal subject = new OnBackToNormal(null, log);
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void shouldMeetConditionIfPreviousFailureIsNowSuccess() {
+        given(context.previousResultOrSuccess()).willReturn(Result.FAILURE);
+        given(context.currentResult()).willReturn(Result.SUCCESS);
+
+        boolean actual = subject.isMetBy(context);
+
+        assertTrue(actual);
+    }
+
+    @Test
+    public void shouldMeetConditionIfPreviousUnstableIsNowSuccess() {
+        given(context.previousResultOrSuccess()).willReturn(Result.UNSTABLE);
+        given(context.currentResult()).willReturn(Result.SUCCESS);
+
+        boolean actual = subject.isMetBy(context);
+
+        assertTrue(actual);
+    }
+
+    @Test
+    public void shouldNotMeetConditionIfCurrentIsNotSuccess() {
+        given(context.previousResultOrSuccess()).willReturn(Result.FAILURE);
+        given(context.currentResult()).willReturn(Result.FAILURE);
+
+        boolean actual = subject.isMetBy(context);
+
+        assertFalse(actual);
+    }
+
+    @Test
+    public void shouldNotMeetConditionIfPreviousIsSuccess() {
+        given(context.previousResultOrSuccess()).willReturn(Result.FAILURE);
+        given(context.currentResult()).willReturn(Result.FAILURE);
+
+        boolean actual = subject.isMetBy(context);
+
+        assertFalse(actual);
+    }
+
+}

--- a/src/test/java/jenkins/plugins/slack/decisions/OnRepeatedFailureTest.java
+++ b/src/test/java/jenkins/plugins/slack/decisions/OnRepeatedFailureTest.java
@@ -1,0 +1,55 @@
+package jenkins.plugins.slack.decisions;
+
+import hudson.model.Result;
+import jenkins.plugins.slack.logging.BuildAwareLogger;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.BDDMockito.given;
+
+public class OnRepeatedFailureTest {
+    @Mock
+    private Context context;
+    @Mock
+    private BuildAwareLogger log;
+    private OnRepeatedFailure condition = new OnRepeatedFailure(null, log);
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void shouldMeetConditionIfCurrentAndPreviousAreFailures() {
+        given(context.previousResultOrSuccess()).willReturn(Result.FAILURE);
+        given(context.currentResult()).willReturn(Result.FAILURE);
+
+        boolean actual = condition.isMetBy(context);
+
+        assertTrue(actual);
+    }
+
+    @Test
+    public void shouldNotMeetConditionIfCurrentIsUnstable() {
+        given(context.previousResultOrSuccess()).willReturn(Result.FAILURE);
+        given(context.currentResult()).willReturn(Result.UNSTABLE);
+
+        boolean actual = condition.isMetBy(context);
+
+        assertFalse(actual);
+    }
+
+    @Test
+    public void shouldNotMeetConditionIfPreviousIsUnstable() {
+        given(context.previousResultOrSuccess()).willReturn(Result.UNSTABLE);
+        given(context.currentResult()).willReturn(Result.FAILURE);
+
+        boolean actual = condition.isMetBy(context);
+
+        assertFalse(actual);
+    }
+}

--- a/src/test/java/jenkins/plugins/slack/decisions/OnSingleFailureTest.java
+++ b/src/test/java/jenkins/plugins/slack/decisions/OnSingleFailureTest.java
@@ -1,0 +1,56 @@
+package jenkins.plugins.slack.decisions;
+
+import hudson.model.Result;
+import jenkins.plugins.slack.logging.BuildAwareLogger;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.BDDMockito.given;
+
+public class OnSingleFailureTest {
+    @Mock
+    private Context context;
+    @Mock
+    private BuildAwareLogger log;
+    private OnSingleFailure condition = new OnSingleFailure(null, log);
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void shouldMeetConditionIfCurrentIsFailureAndPreviousIsUnstable() {
+        given(context.previousResultOrSuccess()).willReturn(Result.UNSTABLE);
+        given(context.currentResult()).willReturn(Result.FAILURE);
+
+        boolean actual = condition.isMetBy(context);
+
+        assertTrue(actual);
+    }
+
+    @Test
+    public void shouldNotMeetConditionIfCurrentIsFailureAndPreviousIsFailure() {
+        given(context.previousResultOrSuccess()).willReturn(Result.FAILURE);
+        given(context.currentResult()).willReturn(Result.FAILURE);
+
+        boolean actual = condition.isMetBy(context);
+
+        assertFalse(actual);
+    }
+
+    @Test
+    public void shouldNotMeetConditionIfCurrentIsSuccess() {
+        given(context.previousResultOrSuccess()).willReturn(Result.FAILURE);
+        given(context.currentResult()).willReturn(Result.SUCCESS);
+
+        boolean actual = condition.isMetBy(context);
+
+        assertFalse(actual);
+    }
+
+}

--- a/src/test/java/jenkins/plugins/slack/logging/SlackNotificationsLoggerTest.java
+++ b/src/test/java/jenkins/plugins/slack/logging/SlackNotificationsLoggerTest.java
@@ -1,0 +1,55 @@
+package jenkins.plugins.slack.logging;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.PrintStream;
+import java.util.function.Supplier;
+import java.util.logging.Logger;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+public class SlackNotificationsLoggerTest {
+    @Mock
+    private Logger system;
+    @Mock
+    private PrintStream user;
+    @Captor
+    private ArgumentCaptor<Supplier<String>> messageSupplier;
+    private SlackNotificationsLogger logger;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        logger = new SlackNotificationsLogger(system, user);
+    }
+
+    @Test
+    public void shouldOnlyWriteDebugMessagesToSystemLog() {
+        String expected = "[key] this message has number 15 within it";
+
+        logger.debug("[key]", "this message has number %d %s it", 15, "within");
+
+        verifyZeroInteractions(user);
+        verify(system).fine(messageSupplier.capture());
+        assertEquals(expected, messageSupplier.getValue().get());
+    }
+
+    @Test
+    public void shouldWriteInfoMessagesToSystemAndUserLogs() {
+        String expectedUserLog = "[Slack Notifications] a 100% useful sort of message";
+        String expectedSystemLog = "[Project #17] a 100% useful sort of message";
+
+        logger.info("[Project #17]", "a %s useful sort %s message", "100%", "of");
+
+        verify(user).println(expectedUserLog);
+        verify(system).info(messageSupplier.capture());
+        assertEquals(expectedSystemLog, messageSupplier.getValue().get());
+    }
+}

--- a/src/test/java/jenkins/plugins/slack/workflow/MessageBuilderTest.java
+++ b/src/test/java/jenkins/plugins/slack/workflow/MessageBuilderTest.java
@@ -4,6 +4,8 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.ItemGroup;
 import jenkins.plugins.slack.ActiveNotifier;
+import jenkins.plugins.slack.TokenExpander;
+import jenkins.plugins.slack.logging.BuildAwareLogger;
 import junit.framework.TestCase;
 import org.junit.Before;
 import org.junit.Test;
@@ -13,6 +15,8 @@ import org.mockito.Mockito;
 
 import java.util.Arrays;
 import java.util.Collection;
+
+import static org.mockito.Mockito.mock;
 
 @RunWith(Parameterized.class)
 public class MessageBuilderTest extends TestCase {
@@ -25,17 +29,17 @@ public class MessageBuilderTest extends TestCase {
     @Before
     @Override
     public void setUp() {
-        messageBuilder = new ActiveNotifier.MessageBuilder(null, build);
+        messageBuilder = new ActiveNotifier.MessageBuilder(null, build, mock(BuildAwareLogger.class), mock(TokenExpander.class));
     }
 
     public MessageBuilderTest(String projectDisplayName, String buildDisplayName, String expectedResult) {
-        this.build = Mockito.mock(FreeStyleBuild.class);
-        FreeStyleProject project = Mockito.mock(FreeStyleProject.class);
+        this.build = mock(FreeStyleBuild.class);
+        FreeStyleProject project = mock(FreeStyleProject.class);
 
         Mockito.when(build.getProject()).thenReturn(project);
         Mockito.when(build.getDisplayName()).thenReturn(buildDisplayName);
 
-        ItemGroup ig = Mockito.mock(ItemGroup.class);
+        ItemGroup ig = mock(ItemGroup.class);
         Mockito.when(ig.getFullDisplayName()).thenReturn("");
         Mockito.when(project.getParent()).thenReturn(ig);
         Mockito.when(project.getDisplayName()).thenReturn(projectDisplayName);


### PR DESCRIPTION
- Extracted Condition interface that let's us log both if the condition
  was met and if the user preference allowed the notification to be sent
- Conditions that have interesting logic are unit-tested
- Moves to the message supplier style of logging, which is not invoked
  unless that level of logging is enabled
- Introduces a build key format - [ProjectFullDisplayName #<build>] to
  better indicate which build the messaging is coming from

Fixes #508 