### PR TITLE
Clarify the messaging around the failure notification options

### DIFF
--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/config.jelly
@@ -24,8 +24,12 @@
         <f:checkbox field="notifyRegression" />
     </f:entry>
 
-    <f:entry title="Notify Failure">
+    <f:entry title="Notify First Failure Only">
         <f:checkbox field="notifyFailure" />
+    </f:entry>
+
+    <f:entry title="Notify Repeated Failure Only">
+        <f:checkbox field="notifyRepeatedFailure" />
     </f:entry>
 
     <f:entry title="Notify Back To Normal">
@@ -33,9 +37,6 @@
     </f:entry>
 
     <f:advanced>
-        <f:entry title="Notify Repeated Failure">
-            <f:checkbox field="notifyRepeatedFailure" />
-        </f:entry>
         <f:entry title="Include Test Summary">
             <f:checkbox field="includeTestSummary" />
         </f:entry>


### PR DESCRIPTION
I noticed issue #518 came up today. It has also been a point of confusion for me in the past. I think clarifying the wording and moving the repeated failure option out of advanced could help.

I think overall I'd prefer just having one "notify on every failure" option, but this would be a nice improvement too.

<img width="384" alt="screen shot 2019-02-14 at 6 38 28 pm" src="https://user-images.githubusercontent.com/230004/52831127-5a4a1200-3088-11e9-902c-f044547bf7bc.png">
