### PR TITLE
Introduce maven-checkstyle-plugin to validate no star imports

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="AvoidStarImport"/>
+    </module>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -228,6 +228,26 @@
                 <groupId>org.jenkins-ci.tools</groupId>
                 <artifactId>maven-hpi-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <configuration>
+                            <configLocation>checkstyle.xml</configLocation>
+                            <encoding>UTF-8</encoding>
+                            <consoleOutput>true</consoleOutput>
+                            <failsOnError>true</failsOnError>
+                        </configuration>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
It'd be great to have the build validate style rules for newer contributors to the project. I added the [AvoidStarImport rule](http://checkstyle.sourceforge.net/config_imports.html#AvoidStarImport) through the [maven-checkstyle-plugin](https://maven.apache.org/plugins/maven-checkstyle-plugin/usage.html#Checking_for_Violations_as_Part_of_the_Build) based on feedback from #516.

Here's how it fails when there is a star import:

```
[INFO] --- maven-checkstyle-plugin:3.0.0:check (validate) @ slack ---
[INFO] Starting audit...
[ERROR] <repo>/slack-plugin/src/main/java/jenkins/plugins/slack/ActiveNotifier.java:6: Using the '.*' form of import should be avoided - hudson.model.*. [AvoidStarImport]
Audit done.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  4.656 s
[INFO] Finished at: 2019-02-15T14:09:19-08:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-checkstyle-plugin:3.0.0:check (validate) on project slack: Failed during checkstyle execution: There is 1 error reported by Checkstyle 6.18 with checkstyle.xml ruleset. -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```