### PR TITLE
Don't append failure number if no tests fail

### DIFF
--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -437,10 +437,12 @@ public class ActiveNotifier implements FineGrainedNotifier {
                     .getAction(AbstractTestResultAction.class);
             if (action != null) {
                 int failed = action.getFailCount();
-                message.append("\n").append(failed).append(" Failed Tests:\n");
-                for(TestResult result : action.getFailedTests()) {
-                    message.append("\t").append(getTestClassAndMethod(result)).append(" after ")
-                            .append(result.getDurationString()).append("\n");
+                if (failed > 0) {
+                    message.append("\n").append(failed).append(" Failed Tests:\n");
+                    for(TestResult result : action.getFailedTests()) {
+                        message.append("\t").append(getTestClassAndMethod(result)).append(" after ")
+                                .append(result.getDurationString()).append("\n");
+                    }
                 }
             }
             return this;


### PR DESCRIPTION
Currently if no tests fail and includeFailedTests is enabled
we append "0 Failed Tests:" to the message.

This brings no value if no tests failed, so in that case we
just don't append anything.

Fixes #435 