### PR TITLE
Fix concurrent build back to normal notification missed

### DIFF
--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -134,7 +134,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
         if (null != previousBuild) {
             do {
                 previousBuild = previousBuild.getPreviousCompletedBuild();
-            } while ((null != previousBuild && previousBuild.getResult() == Result.ABORTED) || previousBuild.getNumber() == r.getNumber());
+            } while ((null != previousBuild && previousBuild.getResult() == Result.ABORTED) || (null != previousBuild && previousBuild.getNumber() == r.getNumber()));
             if (null != previousBuild) {
                 log.info(key, "found #%d as previous completed, non-aborted build", previousBuild.getNumber());
             } else {

--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -134,7 +134,7 @@ public class ActiveNotifier implements FineGrainedNotifier {
         if (null != previousBuild) {
             do {
                 previousBuild = previousBuild.getPreviousCompletedBuild();
-            } while (null != previousBuild && previousBuild.getResult() == Result.ABORTED);
+            } while ((null != previousBuild && previousBuild.getResult() == Result.ABORTED) || previousBuild.getNumber() == r.getNumber());
             if (null != previousBuild) {
                 log.info(key, "found #%d as previous completed, non-aborted build", previousBuild.getNumber());
             } else {


### PR DESCRIPTION
Fixes #544 

Added a check to make sure that the same builds aren't being compared with each other.  

It seems like when two concurrent builds are happening, the context for the `project` variable gets changed so the `project.getLastBuild()` ends up returning the newest build even though `r` is still the earlier of the two.  This makes `r` and `previousBuild` refer to the same build and break the `OnBackToNormal` check.


