### PR TITLE
Always set the Content-Type Header

### DIFF
--- a/src/main/java/jenkins/plugins/slack/StandardSlackService.java
+++ b/src/main/java/jenkins/plugins/slack/StandardSlackService.java
@@ -179,7 +179,6 @@ public class StandardSlackService implements SlackService {
 
                 post = new HttpPost(url);
                 post.setHeader("Authorization", "Bearer " + populatedToken);
-                post.setHeader("Content-type", "application/json");
                 if (threadTs.length() > 1) {
                     json.put("thread_ts", threadTs);
                 }
@@ -203,6 +202,7 @@ public class StandardSlackService implements SlackService {
             CloseableHttpClient client = getHttpClient();
 
             try {
+                post.setHeader("Content-Type", "application/json");
                 post.setEntity(new StringEntity(json.toString(), StandardCharsets.UTF_8));
                 CloseableHttpResponse response = client.execute(post);
 


### PR DESCRIPTION
Also set the Content-Type Header for webhook requests.

This allows this plugin to work with Slack-compatible Webhooks that require a correctly set Content-Type Header.
For Example: https://t2bot.io/webhooks/