### PR TITLE
Provide NTCredentials for NTLM authentication

### DIFF
--- a/src/main/java/jenkins/plugins/slack/HttpClient.java
+++ b/src/main/java/jenkins/plugins/slack/HttpClient.java
@@ -3,6 +3,8 @@ package jenkins.plugins.slack;
 import hudson.ProxyConfiguration;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.Credentials;
+import org.apache.http.auth.NTCredentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.config.RequestConfig;
@@ -40,10 +42,20 @@ public class HttpClient {
             // Consider it to be passed if username specified. Sufficient?
             if (username != null && !"".equals(username.trim())) {
                 credentialsProvider.setCredentials(new AuthScope(proxyHost),
-                        new UsernamePasswordCredentials(username, password));
+                        createCredentials(username, password));
             }
         }
         return clientBuilder.build();
+    }
+
+    private static Credentials createCredentials(String userName, String password) {
+        if (userName.indexOf('\\') >= 0){
+            final String domain = userName.substring(0, userName.indexOf('\\'));
+            final String user = userName.substring(userName.indexOf('\\') + 1);
+            return new NTCredentials(user, password, "", domain);
+        } else {
+            return new UsernamePasswordCredentials(userName, password);
+        }
     }
 
 }


### PR DESCRIPTION
Publishing a message to Slack through a proxy that uses NTLM authentication doesn't seem to work:
```
2020-01-31 11:47:46.776+0000 [id=123828]        WARNING o.a.h.i.auth.HttpAuthenticator#generateAuthResponse: NEGOTIATE authentication error: No valid credentials provided (Mechanism level: No valid credentials provided (Mechanism level: Failed to find any Kerberos tgt))
2020-01-31 11:47:46.776+0000 [id=123828]        WARNING o.a.h.i.auth.HttpAuthenticator#generateAuthResponse: NTLM authentication error: Credentials cannot be used for NTLM authentication: org.apache.http.auth.UsernamePasswordCredentials
2020-01-31 11:47:46.781+0000 [id=123828]        WARNING j.p.slack.StandardSlackService#publish: Slack post may have failed. Response: null
2020-01-31 11:47:46.783+0000 [id=123828]        WARNING j.p.slack.StandardSlackService#publish: Response Code: 407
```

NTLM authentication (for Apache HttpClient 4.5.x) requires that an instance of `NTCredentials` is provided. See [`NTLMScheme`](https://github.com/apache/httpcomponents-client/blob/4.5.x/httpclient/src/main/java/org/apache/http/impl/auth/NTLMScheme.java#L126-L132).

This plugin will therefore need to provide an instance of `NTCredentials`, similar to how it's done in Jenkins' [`ProxyConfiguration`](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/ProxyConfiguration.java#L484-L492).

A limitation of this solution is that it will not be able to connect to a non-NTLM proxy with a `\` in the username (if that's even a valid character). See discussion here: [https://github.com/jenkinsci/jenkins/pull/1955](https://github.com/jenkinsci/jenkins/pull/1955).