### PR TITLE
add OnRegression NotificationConditions

### DIFF
--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -10,7 +10,6 @@ import hudson.model.Run;
 import hudson.scm.ChangeLogSet;
 import hudson.scm.ChangeLogSet.AffectedFile;
 import hudson.scm.ChangeLogSet.Entry;
-import hudson.tasks.junit.TestResultAction;
 import hudson.tasks.test.AbstractTestResultAction;
 import hudson.tasks.test.TestResult;
 import hudson.triggers.SCMTrigger;

--- a/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/ActiveNotifier.java
@@ -102,26 +102,6 @@ public class ActiveNotifier implements FineGrainedNotifier {
     }
 
     public void finalized(AbstractBuild r) {
-        if (skipOnMatrixChildren(r)) {
-            return;
-        }
-        AbstractProject<?, ?> project = r.getProject();
-        Result result = r.getResult();
-        AbstractBuild<?, ?> previousBuild = project.getLastBuild();
-        if (null != previousBuild) {
-            do {
-                previousBuild = previousBuild.getPreviousCompletedBuild();
-            } while (previousBuild != null && previousBuild.getResult() == Result.ABORTED);
-            Result previousResult = (previousBuild != null) ? previousBuild.getResult() : Result.SUCCESS;
-            if(null != previousResult && (result != null && result.isWorseThan(previousResult) || moreTestFailuresThanPreviousBuild(r, previousBuild)) && notifier.getNotifyRegression()) {
-                String message = getBuildStatusMessage(r, notifier.getIncludeTestSummary(),
-                        notifier.getIncludeFailedTests(), notifier.getIncludeCustomMessage());
-                if (notifier.getCommitInfoChoice().showAnything()) {
-                    message = message + "\n" + getCommitList(r);
-                }
-                slackFactory.apply(r).publish(message, getBuildColor(r));
-            }
-        }
     }
 
     public void completed(AbstractBuild r) {
@@ -159,31 +139,6 @@ public class ActiveNotifier implements FineGrainedNotifier {
             return !(matrixTriggerMode != null && matrixTriggerMode.forChild);
         }
         return false;
-    }
-
-    private boolean moreTestFailuresThanPreviousBuild(AbstractBuild currentBuild, AbstractBuild<?, ?> previousBuild) {
-        if (getTestResult(currentBuild) != null && getTestResult(previousBuild) != null) {
-            if (getTestResult(currentBuild).getFailCount() > getTestResult(previousBuild).getFailCount())
-                return true;
-
-            // test if different tests failed.
-            return !getFailedTestIds(currentBuild).equals(getFailedTestIds(previousBuild));
-        }
-        return false;
-    }
-
-    private TestResultAction getTestResult(AbstractBuild build) {
-        return build.getAction(TestResultAction.class);
-    }
-
-    private Set<String> getFailedTestIds(AbstractBuild currentBuild) {
-        Set<String> failedTestIds = new HashSet<>();
-        List<? extends TestResult> failedTests = getTestResult(currentBuild).getFailedTests();
-        for(TestResult result : failedTests) {
-            failedTestIds.add(result.getId());
-        }
-
-        return failedTestIds;
     }
 
     String getChanges(AbstractBuild r, boolean includeCustomMessage) {

--- a/src/main/java/jenkins/plugins/slack/SlackNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/SlackNotifier.java
@@ -586,10 +586,6 @@ public class SlackNotifier extends Notifier {
         JenkinsTokenExpander tokenExpander = new JenkinsTokenExpander(listener);
         try {
             new ActiveNotifier(this, slackFactory(listener), log, tokenExpander).completed(build);
-            if (notifyRegression) {
-                log.debug(buildKey, "Performing finalize notifications");
-                new ActiveNotifier(this, slackFactory(listener), log, tokenExpander).finalized(build);
-            }
         } catch (Exception e) {
             log.info(buildKey,"Exception attempting Slack notification: " + e.getMessage());
         }

--- a/src/main/java/jenkins/plugins/slack/decisions/Context.java
+++ b/src/main/java/jenkins/plugins/slack/decisions/Context.java
@@ -2,6 +2,7 @@ package jenkins.plugins.slack.decisions;
 
 import hudson.model.AbstractBuild;
 import hudson.model.Result;
+import hudson.tasks.junit.TestResultAction;
 import javax.annotation.Nullable;
 import jenkins.plugins.slack.logging.BuildKey;
 
@@ -31,5 +32,28 @@ public class Context {
             return null;
         }
         return current.getResult();
+    }
+
+    public Result currentResultOrSuccess() {
+        if (current == null || current.getResult() == null) {
+            return Result.SUCCESS;
+        }
+        return current.getResult();
+    }
+
+    @Nullable
+    private TestResultAction getTestResult(AbstractBuild<?, ?> build) {
+        if (build == null) { return null; }
+        return build.getAction(TestResultAction.class);
+    }
+
+    @Nullable
+    public TestResultAction getPreviousTestResult() {
+        return getTestResult(previous);
+    }
+
+    @Nullable
+    public TestResultAction getCurrentTestResult() {
+        return getTestResult(current);
     }
 }

--- a/src/main/java/jenkins/plugins/slack/decisions/NotificationConditions.java
+++ b/src/main/java/jenkins/plugins/slack/decisions/NotificationConditions.java
@@ -22,6 +22,7 @@ public class NotificationConditions implements Predicate<Context> {
                 new OnNotBuilt(preferences, log),
                 new OnBackToNormal(preferences, log),
                 new OnSuccess(preferences, log),
+                new OnRegression(preferences, log),
                 new OnUnstable(preferences, log)
         ));
     }

--- a/src/main/java/jenkins/plugins/slack/decisions/OnRegression.java
+++ b/src/main/java/jenkins/plugins/slack/decisions/OnRegression.java
@@ -1,0 +1,58 @@
+package jenkins.plugins.slack.decisions;
+
+import hudson.tasks.junit.TestResultAction;
+import hudson.tasks.test.TestResult;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import jenkins.plugins.slack.SlackNotifier;
+import jenkins.plugins.slack.logging.BuildAwareLogger;
+
+public class OnRegression implements Condition {
+    private final SlackNotifier preferences;
+    private final BuildAwareLogger log;
+
+    public OnRegression(SlackNotifier preferences, BuildAwareLogger log) {
+        this.preferences = preferences;
+        this.log = log;
+    }
+
+    @Override
+    public boolean isMetBy(Context context) {
+        return context.currentResultOrSuccess().isWorseThan(context.previousResultOrSuccess())
+            || moreTestFailuresThanPrevious(context);
+    }
+
+    @Override
+    public boolean userPreferenceMatches() {
+        return preferences.getNotifyRegression();
+    }
+
+    @Override
+    public BuildAwareLogger log() {
+        return log;
+    }
+
+    public boolean moreTestFailuresThanPrevious(Context context) {
+        TestResultAction currentTestResult = context.getCurrentTestResult();
+        TestResultAction previousTestResult = context.getPreviousTestResult();
+        if (currentTestResult != null && previousTestResult != null) {
+            if (currentTestResult.getFailCount() > previousTestResult.getFailCount())
+                return true;
+
+            // test if different tests failed.
+            return !getFailedTestIds(currentTestResult).equals(getFailedTestIds(previousTestResult));
+        }
+        return false;
+    }
+
+    private Set<String> getFailedTestIds(TestResultAction testResultAction) {
+        Set<String> failedTestIds = new HashSet<>();
+        List<? extends TestResult> failedTests = testResultAction.getFailedTests();
+        for (TestResult result : failedTests) {
+            failedTestIds.add(result.getId());
+        }
+        return failedTestIds;
+    }
+
+}

--- a/src/main/java/jenkins/plugins/slack/decisions/OnRegression.java
+++ b/src/main/java/jenkins/plugins/slack/decisions/OnRegression.java
@@ -33,7 +33,7 @@ public class OnRegression implements Condition {
         return log;
     }
 
-    public boolean moreTestFailuresThanPrevious(Context context) {
+    private boolean moreTestFailuresThanPrevious(Context context) {
         TestResultAction currentTestResult = context.getCurrentTestResult();
         TestResultAction previousTestResult = context.getPreviousTestResult();
         if (currentTestResult != null && previousTestResult != null) {

--- a/src/test/java/jenkins/plugins/slack/decisions/OnRegressionTest.java
+++ b/src/test/java/jenkins/plugins/slack/decisions/OnRegressionTest.java
@@ -1,10 +1,7 @@
 package jenkins.plugins.slack.decisions;
 
-import hudson.model.AbstractBuild;
 import hudson.model.Result;
-import hudson.tasks.junit.TestResult;
 import hudson.tasks.junit.TestResultAction;
-import java.util.Collections;
 import jenkins.plugins.slack.logging.BuildAwareLogger;
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/jenkins/plugins/slack/decisions/OnRegressionTest.java
+++ b/src/test/java/jenkins/plugins/slack/decisions/OnRegressionTest.java
@@ -1,0 +1,82 @@
+package jenkins.plugins.slack.decisions;
+
+import hudson.model.AbstractBuild;
+import hudson.model.Result;
+import hudson.tasks.junit.TestResult;
+import hudson.tasks.junit.TestResultAction;
+import java.util.Collections;
+import jenkins.plugins.slack.logging.BuildAwareLogger;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.BDDMockito.given;
+
+public class OnRegressionTest {
+    @Mock
+    private Context context;
+    @Mock
+    private BuildAwareLogger log;
+    @Mock
+    private TestResultAction previousTestResult;
+    @Mock
+    private TestResultAction currentTestResult;
+
+    private OnRegression condition = new OnRegression(null, log);
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void shouldMeetConditionIfCurrentIsWorseThanPrevious() {
+        given(context.currentResultOrSuccess()).willReturn(Result.FAILURE);
+        given(context.previousResultOrSuccess()).willReturn(Result.SUCCESS);
+
+        boolean actual = condition.isMetBy(context);
+
+        assertTrue(actual);
+    }
+
+    @Test
+    public void shouldNotMeetConditionIfCurrentIsBetterThanPrevious() {
+        given(context.currentResultOrSuccess()).willReturn(Result.SUCCESS);
+        given(context.previousResultOrSuccess()).willReturn(Result.FAILURE);
+
+        boolean actual = condition.isMetBy(context);
+
+        assertFalse(actual);
+    }
+
+    @Test
+    public void shouldMeetConditionIfCurrentIsHasMoreTestFailuresThanPrevious() {
+        given(context.currentResultOrSuccess()).willReturn(Result.UNSTABLE);
+        given(context.previousResultOrSuccess()).willReturn(Result.UNSTABLE);
+        given(context.getPreviousTestResult()).willReturn(previousTestResult);
+        given(context.getCurrentTestResult()).willReturn(currentTestResult);
+        given(previousTestResult.getFailCount()).willReturn(1);
+        given(currentTestResult.getFailCount()).willReturn(10);
+
+        boolean actual = condition.isMetBy(context);
+
+        assertTrue(actual);
+    }
+
+    @Test
+    public void shouldNotMeetConditionIfCurrentIsHasFewerTestFailuresThanPrevious() {
+        given(context.currentResultOrSuccess()).willReturn(Result.UNSTABLE);
+        given(context.previousResultOrSuccess()).willReturn(Result.UNSTABLE);
+        given(context.getPreviousTestResult()).willReturn(previousTestResult);
+        given(context.getCurrentTestResult()).willReturn(currentTestResult);
+        given(previousTestResult.getFailCount()).willReturn(10);
+        given(currentTestResult.getFailCount()).willReturn(1);
+
+        boolean actual = condition.isMetBy(context);
+
+        assertFalse(actual);
+    }
+}


### PR DESCRIPTION
fixes #681 
fixes #322 

This should fix those who got two notifications when notify regression was ticked.

Looking through how many places `ActiveNotifier` is used there should no longer be a case for double notifications.