### PR TITLE
Follow the established exception handling convention.

### DIFF
--- a/src/main/java/jenkins/plugins/slack/SlackNotifier.java
+++ b/src/main/java/jenkins/plugins/slack/SlackNotifier.java
@@ -584,11 +584,7 @@ public class SlackNotifier extends Notifier {
         BuildAwareLogger log = createLogger(listener);
         log.debug(buildKey, "Performing complete notifications");
         JenkinsTokenExpander tokenExpander = new JenkinsTokenExpander(listener);
-        try {
-            new ActiveNotifier(this, slackFactory(listener), log, tokenExpander).completed(build);
-        } catch (Exception e) {
-            log.info(buildKey,"Exception attempting Slack notification: " + e.getMessage());
-        }
+        new ActiveNotifier(this, slackFactory(listener), log, tokenExpander).completed(build);
         return true;
     }
 
@@ -596,13 +592,9 @@ public class SlackNotifier extends Notifier {
     public boolean prebuild(AbstractBuild<?, ?> build, BuildListener listener) {
         String buildKey = BuildKey.format(build);
         BuildAwareLogger log = createLogger(listener);
-        try {
-            if (startNotification) {
-                log.debug(buildKey, "Performing start notifications");
-                new ActiveNotifier(this, slackFactory(listener), log, new JenkinsTokenExpander(listener)).started(build);
-            }
-        } catch (Exception e) {
-            log.info(buildKey,"Exception attempting Slack notification: " + e.getMessage());
+        if (startNotification) {
+            log.debug(buildKey, "Performing start notifications");
+            new ActiveNotifier(this, slackFactory(listener), log, new JenkinsTokenExpander(listener)).started(build);
         }
         return super.prebuild(build, listener);
     }


### PR DESCRIPTION
The general established behaviours in BuildStep is to simply let the
caller handle the exception, possibly with exception chaining to add
more context.

What the code does right now is to simply swallow the stack trace part
of the exception, which is often the most crucial, especially for
unanticipated exceptions (in this context, there's no checked exceptions
thrown.)

See issues like https://github.com/jenkinsci/slack-plugin/issues/595
where this behaviour makes it painful for users (and maintainers) to
troubleshoot what's going on.
