### PR TITLE
Don't use saved global params when testing globally

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.6</version>
+        <version>4.7</version>
     </parent>
 
     <artifactId>slack</artifactId>

--- a/src/main/resources/jenkins/plugins/slack/SlackNotifier/global.jelly
+++ b/src/main/resources/jenkins/plugins/slack/SlackNotifier/global.jelly
@@ -33,7 +33,7 @@
         </f:advanced>
         <f:validateButton
                 title="${%Test Connection}" progress="${%Testing...}"
-                method="testConnection"
+                method="testConnectionGlobal"
                 with="baseUrl,teamDomain,token,tokenCredentialId,botUser,sendAsText,iconEmoji,username,room"/>
     </f:section>
 </j:jelly>


### PR DESCRIPTION
Ignores saved configuration, only uses configuration currently in the form

See https://github.com/jenkinsci/slack-plugin/issues/728#issuecomment-689022347