### PR TITLE
Fix NPE in `SlackUserIdResolver#resolveUseId(User)`

### DIFF
--- a/src/main/java/jenkins/plugins/slack/user/EmailSlackUserIdResolver.java
+++ b/src/main/java/jenkins/plugins/slack/user/EmailSlackUserIdResolver.java
@@ -60,15 +60,12 @@ public class EmailSlackUserIdResolver extends SlackUserIdResolver {
     private static final String SLACK_USER_FIELD = "user";
     private static final String SLACK_ID_FIELD = "id";
 
-    private String authToken;
-    private CloseableHttpClient httpClient;
     private List<MailAddressResolver> mailAddressResolvers;
     private Function<User, String> defaultMailAddressResolver;
 
     @VisibleForTesting
     EmailSlackUserIdResolver(String authToken, CloseableHttpClient httpClient, List<MailAddressResolver> mailAddressResolvers, Function<User, String> defaultMailAddressResolver) {
-        this.authToken = authToken;
-        this.httpClient = httpClient;
+        super(authToken, httpClient);
         this.mailAddressResolvers = mailAddressResolvers;
         this.defaultMailAddressResolver = defaultMailAddressResolver;
     }
@@ -88,14 +85,6 @@ public class EmailSlackUserIdResolver extends SlackUserIdResolver {
 
     public String getAPIMethodURL() {
         return LOOKUP_BY_EMAIL_METHOD_URL;
-    }
-
-    public void setAuthToken(String authToken) {
-        this.authToken = authToken;
-    }
-
-    public void setHttpClient(CloseableHttpClient httpClient) {
-        this.httpClient = httpClient;
     }
 
     public void setMailAddressResolvers(List<MailAddressResolver> mailAddressResolvers) {

--- a/src/main/java/jenkins/plugins/slack/user/EmailSlackUserIdResolver.java
+++ b/src/main/java/jenkins/plugins/slack/user/EmailSlackUserIdResolver.java
@@ -109,11 +109,13 @@ public class EmailSlackUserIdResolver extends SlackUserIdResolver {
                 .filter(StringUtils::isNotEmpty)
                 .findAny();
 
+        // Return value can be null, so Optional.orElseGet(Supplier) doesn't work.
         if (userId.isPresent()) {
             return userId.get();
-        } else {
-            // Return value can be null, so Optional.orElseGet(Supplier) doesn't work.
+        } else if (defaultMailAddressResolver != null){
             return resolveUserIdForEmailAddress(defaultMailAddressResolver.apply(user));
+        } else {
+            return null;
         }
     }
 

--- a/src/main/java/jenkins/plugins/slack/user/NoSlackUserIdResolver.java
+++ b/src/main/java/jenkins/plugins/slack/user/NoSlackUserIdResolver.java
@@ -31,6 +31,7 @@ public class NoSlackUserIdResolver extends SlackUserIdResolver {
 
     @DataBoundConstructor
     public NoSlackUserIdResolver() {
+        super(null, null);
     }
 
     protected String resolveUserId(User user) {

--- a/src/main/java/jenkins/plugins/slack/user/SlackUserIdResolver.java
+++ b/src/main/java/jenkins/plugins/slack/user/SlackUserIdResolver.java
@@ -49,8 +49,13 @@ public abstract class SlackUserIdResolver extends AbstractDescribableImpl<SlackU
 
     private static final Logger LOGGER = Logger.getLogger(SlackUserIdResolver.class.getName());
 
-    private String authToken;
-    private CloseableHttpClient httpClient;
+    protected String authToken;
+    protected CloseableHttpClient httpClient;
+
+    protected SlackUserIdResolver(String authToken, CloseableHttpClient httpClient) {
+        this.authToken = authToken;
+        this.httpClient = httpClient;
+    }
 
     public final String findOrResolveUserId(User user) {
         String userId = null;

--- a/src/test/java/jenkins/plugins/slack/user/EmailSlackUserIdResolverTest.java
+++ b/src/test/java/jenkins/plugins/slack/user/EmailSlackUserIdResolverTest.java
@@ -123,6 +123,16 @@ public class EmailSlackUserIdResolverTest {
     }
 
     @Test
+    public void testResolveUserIdForUserWithoutDefaultMailAddressResolver() throws Exception {
+        mailAddressResolver = mock(MailAddressResolver.class);
+        resolver = new EmailSlackUserIdResolver(AUTH_TOKEN, httpClient, Collections.singletonList(mailAddressResolver), null);
+        httpClient.setHttpResponse(getResponseOK());
+
+        String userId = resolver.resolveUserId(mock(User.class));
+        assertNull(userId);
+    }
+
+    @Test
     public void testResolveUserIdForUserWithoutResolver() throws Exception {
 
         resolver = new EmailSlackUserIdResolver(AUTH_TOKEN, httpClient, null, user -> {return EMAIL_ADDRESS;});

--- a/src/test/java/jenkins/plugins/slack/user/EmailSlackUserIdResolverTest.java
+++ b/src/test/java/jenkins/plugins/slack/user/EmailSlackUserIdResolverTest.java
@@ -30,6 +30,7 @@ import hudson.tasks.MailAddressResolver;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import jenkins.plugins.slack.CloseableHttpClientStub;
 import jenkins.plugins.slack.CloseableHttpResponseStub;
@@ -98,6 +99,16 @@ public class EmailSlackUserIdResolverTest {
         httpClient.setHttpResponse(getResponseOK());
         String userId = resolver.findOrResolveUserId(mock(User.class));
         assertEquals(EXPECTED_USER_ID, userId);
+    }
+
+    @Test
+    public void testResolveUserIdForUserWithoutEmailAddress() throws Exception {
+        mailAddressResolver = mock(MailAddressResolver.class);
+        resolver = new EmailSlackUserIdResolver(AUTH_TOKEN, httpClient, Collections.singletonList(mailAddressResolver), user -> null);
+        httpClient.setHttpResponse(getResponseOK());
+
+        String userId = resolver.resolveUserId(mock(User.class));
+        assertNull(userId);
     }
 
     @Test

--- a/src/test/java/jenkins/plugins/slack/user/EmailSlackUserIdResolverTest.java
+++ b/src/test/java/jenkins/plugins/slack/user/EmailSlackUserIdResolverTest.java
@@ -112,6 +112,17 @@ public class EmailSlackUserIdResolverTest {
     }
 
     @Test
+    public void testResolveUserIdWithoutAuthToken() throws Exception {
+        mailAddressResolver = mock(MailAddressResolver.class);
+        resolver = new EmailSlackUserIdResolver(AUTH_TOKEN, httpClient, Collections.singletonList(mailAddressResolver), user -> EMAIL_ADDRESS);
+        resolver.setAuthToken(null);
+        httpClient.setHttpResponse(getResponseOK());
+
+        String userId = resolver.resolveUserId(mock(User.class));
+        assertNull(userId);
+    }
+
+    @Test
     public void testResolveUserIdForUserWithoutResolver() throws Exception {
 
         resolver = new EmailSlackUserIdResolver(AUTH_TOKEN, httpClient, null, user -> {return EMAIL_ADDRESS;});


### PR DESCRIPTION
`SlackUserIdResolver#resolveUserIdForEmailAddress(String)` could return `null` if the user doesn't have an email address or if no authentication token has been set.

The call to [`Optional#orElseGet(Supplier)`](https://docs.oracle.com/javase/8/docs/api/java/util/Optional.html#orElseGet-java.util.function.Supplier-) would then fail with a `NullPointerException`:
<details>
<summary>Example exception</summary>

```
java.lang.NullPointerException
    at jenkins.plugins.slack.user.EmailSlackUserIdResolver.lambda$resolveUserId$1(EmailSlackUserIdResolver.java:122)
    at java.base/java.util.Optional.orElseGet(Optional.java:369)
    at jenkins.plugins.slack.user.EmailSlackUserIdResolver.resolveUserId(EmailSlackUserIdResolver.java:122)
    at jenkins.plugins.slack.user.SlackUserIdResolver.findOrResolveUserId(SlackUserIdResolver.java:65)
    at jenkins.plugins.slack.user.SlackUserIdResolver.lambda$resolveUserIdsForChangeLogSet$0(SlackUserIdResolver.java:97)
    at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
    at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:948)
    at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
    at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
    at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
    at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
    at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
    at jenkins.plugins.slack.user.SlackUserIdResolver.resolveUserIdsForChangeLogSet(SlackUserIdResolver.java:99)
    at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
    at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655)
    at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
    at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
    at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
    at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
    at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
    at jenkins.plugins.slack.user.SlackUserIdResolver.resolveUserIdsForChangeLogSets(SlackUserIdResolver.java:106)
    at jenkins.plugins.slack.user.SlackUserIdResolver.resolveUserIdsForRun(SlackUserIdResolver.java:86)
    at jenkins.plugins.slack.StandardSlackService.publish(StandardSlackService.java:290)
    at jenkins.plugins.slack.StandardSlackService.publish(StandardSlackService.java:379)
    at jenkins.plugins.slack.StandardSlackService.publish(StandardSlackService.java:351)
    at jenkins.plugins.slack.workflow.SlackSendStep$SlackSendStepExecution.run(SlackSendStep.java:361)
    at jenkins.plugins.slack.workflow.SlackSendStep$SlackSendStepExecution.run(SlackSendStep.java:258)
    at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution.lambda$start$0(SynchronousNonBlockingStepExecution.java:47)
```
</details>

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue