### PR TITLE
Allow users to use botUser in slackSend even if global URL is set

### DIFF
--- a/src/main/java/jenkins/plugins/slack/StandardSlackService.java
+++ b/src/main/java/jenkins/plugins/slack/StandardSlackService.java
@@ -194,7 +194,7 @@ public class StandardSlackService implements SlackService {
             HttpPost post;
             String url;
 
-            if (!botUser || StringUtils.isNotEmpty(baseUrl)) {
+            if (!botUser) {
                 url = "https://" + teamDomain + "." + "slack.com" + "/services/hooks/jenkins-ci?token=" + populatedToken;
                 if (!StringUtils.isEmpty(baseUrl)) {
                     url = baseUrl + populatedToken;


### PR DESCRIPTION
Having a global URL set makes the "URL is not empty" check always true, making it impossible for our pipeline to use the botUser and tokenCredentialId params for slackSend.

Fixes #798