### PR TITLE
ignore @dependabot upgrades for checkstyle >= 10 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      # Checkstyle >=10 requires Java 11+
+      - dependency-name: "com.puppycrawl.tools:checkstyle"
+        versions: [">= 10.0"]
+        

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,4 +12,3 @@ updates:
       # Checkstyle >=10 requires Java 11+
       - dependency-name: "com.puppycrawl.tools:checkstyle"
         versions: [">= 10.0"]
-        


### PR DESCRIPTION
Reconfiguring @dependabot for this project not to suggest upgrades of Checkstyle beyond 10.x which requires Java 11+.

I.e. see #845 which fail the checks.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue