### PR TITLE
Support messages with blocks and attachments

### DIFF
--- a/src/main/java/jenkins/plugins/slack/SlackRequest.java
+++ b/src/main/java/jenkins/plugins/slack/SlackRequest.java
@@ -13,7 +13,7 @@ public class SlackRequest {
     private final JSONArray blocks;
 
     private SlackRequest(String message, String color, JSONArray attachments, JSONArray blocks, String timestamp) {
-        if (blocks != null && color != null) {
+        if ((blocks != null && attachments == null) && color != null) {
             throw new IllegalArgumentException("Color is not supported when blocks are set");
         }
 


### PR DESCRIPTION
Updates `SlackRequest` and `SlackSendStep` to support creating messages with both attachments and blocks included. I updated `SlackRequest` so that the argument exception won't be thrown any time attachments is supplied as well. Happy to make any changes, thanks for reviewing!

Closes #848

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
