### PR TITLE
Remove duplicated proxy configuration

### DIFF
--- a/src/main/java/jenkins/plugins/slack/HttpClient.java
+++ b/src/main/java/jenkins/plugins/slack/HttpClient.java
@@ -1,7 +1,7 @@
 package jenkins.plugins.slack;
 
 import hudson.ProxyConfiguration;
-import jenkins.plugins.slack.NoProxyHostCheckerRoutePlanner;
+import jenkins.model.Jenkins;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
@@ -20,7 +20,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 @Restricted(NoExternalUse.class)
 public class HttpClient {
 
-    public static CloseableHttpClient getCloseableHttpClient(ProxyConfiguration proxy) {
+    public static CloseableHttpClient getCloseableHttpClient() {
         int timeoutInSeconds = 60;
 
         RequestConfig config = RequestConfig.custom()
@@ -35,6 +35,8 @@ public class HttpClient {
         final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
         clientBuilder.setDefaultCredentialsProvider(credentialsProvider);
 
+        Jenkins jenkins = Jenkins.getInstanceOrNull();
+        ProxyConfiguration proxy = jenkins != null ? jenkins.proxy : null;
         if (proxy != null) {
             final HttpHost proxyHost = new HttpHost(proxy.name, proxy.port);
             final HttpRoutePlanner routePlanner = new NoProxyHostCheckerRoutePlanner(proxy.getNoProxyHost(), proxyHost);

--- a/src/main/java/jenkins/plugins/slack/StandardSlackService.java
+++ b/src/main/java/jenkins/plugins/slack/StandardSlackService.java
@@ -2,7 +2,6 @@ package jenkins.plugins.slack;
 
 import com.google.common.annotations.VisibleForTesting;
 import hudson.FilePath;
-import hudson.ProxyConfiguration;
 import hudson.Util;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -19,7 +18,6 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import jenkins.model.Jenkins;
 import jenkins.plugins.slack.pipeline.SlackFileRequest;
 import jenkins.plugins.slack.pipeline.SlackUploadFileRunner;
 import jenkins.plugins.slack.user.SlackUserIdResolver;
@@ -259,7 +257,7 @@ public class StandardSlackService implements SlackService {
                 SlackFileRequest slackFileRequest = new SlackFileRequest(
                 workspace, populatedToken, roomId, null, artifactIncludes);
                 try {
-                    workspace.getChannel().callAsync(new SlackUploadFileRunner(log, Jenkins.get().proxy, slackFileRequest)).get();
+                    workspace.getChannel().callAsync(new SlackUploadFileRunner(log, slackFileRequest)).get();
                 } catch (IllegalStateException | InterruptedException e) {
                     logger.log(Level.WARNING, "Exception", e);
                     result = false;
@@ -467,9 +465,7 @@ public class StandardSlackService implements SlackService {
     }
 
     protected CloseableHttpClient getHttpClient() {
-        Jenkins jenkins = Jenkins.getInstanceOrNull();
-        ProxyConfiguration proxy = jenkins != null ? jenkins.proxy : null;
-        return HttpClient.getCloseableHttpClient(proxy);
+        return HttpClient.getCloseableHttpClient();
     }
 
     @VisibleForTesting

--- a/src/main/java/jenkins/plugins/slack/pipeline/SlackUploadFileRunner.java
+++ b/src/main/java/jenkins/plugins/slack/pipeline/SlackUploadFileRunner.java
@@ -1,7 +1,6 @@
 package jenkins.plugins.slack.pipeline;
 
 import hudson.FilePath;
-import hudson.ProxyConfiguration;
 import hudson.model.TaskListener;
 import hudson.util.DirScanner;
 import hudson.util.FileVisitor;
@@ -41,16 +40,14 @@ public class SlackUploadFileRunner extends MasterToSlaveCallable<Boolean, Throwa
 
     private final TaskListener listener;
     private final String initialComment;
-    private final ProxyConfiguration proxy;
 
-    public SlackUploadFileRunner(TaskListener listener, ProxyConfiguration proxy, SlackFileRequest slackFileRequest) {
+    public SlackUploadFileRunner(TaskListener listener, SlackFileRequest slackFileRequest) {
         this.listener = listener;
         this.filePath = slackFileRequest.getFilePath();
         this.fileToUploadPath = slackFileRequest.getFileToUploadPath();
         this.channels = slackFileRequest.getChannels();
         this.initialComment = slackFileRequest.getInitialComment();
         this.token = slackFileRequest.getToken();
-        this.proxy = proxy;
     }
 
     @Override
@@ -79,7 +76,7 @@ public class SlackUploadFileRunner extends MasterToSlaveCallable<Boolean, Throwa
     }
 
     private boolean doIt(List<File> files) {
-            CloseableHttpClient client = HttpClient.getCloseableHttpClient(proxy);
+            CloseableHttpClient client = HttpClient.getCloseableHttpClient();
             String threadTs = null;
             String theChannels = channels;
 

--- a/src/main/java/jenkins/plugins/slack/pipeline/SlackUploadFileStep.java
+++ b/src/main/java/jenkins/plugins/slack/pipeline/SlackUploadFileStep.java
@@ -134,7 +134,7 @@ public class SlackUploadFileStep extends Step {
             VirtualChannel virtualChannel = filePath.getChannel();
             assert virtualChannel != null;
 
-            virtualChannel.callAsync(new SlackUploadFileRunner(listener, Jenkins.get().proxy, slackFileRequest)).get();
+            virtualChannel.callAsync(new SlackUploadFileRunner(listener, slackFileRequest)).get();
 
             return null;
         }

--- a/src/main/java/jenkins/plugins/slack/pipeline/SlackUserIdFromEmailStep.java
+++ b/src/main/java/jenkins/plugins/slack/pipeline/SlackUserIdFromEmailStep.java
@@ -3,7 +3,6 @@ package jenkins.plugins.slack.pipeline;
 import com.google.common.collect.ImmutableSet;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
-import hudson.ProxyConfiguration;
 import hudson.Util;
 import hudson.model.Item;
 import hudson.model.Run;
@@ -150,9 +149,7 @@ public class SlackUserIdFromEmailStep extends Step {
         }
 
         protected CloseableHttpClient getHttpClient() {
-            final Jenkins jenkins = Jenkins.getInstanceOrNull();
-            final ProxyConfiguration proxy = jenkins != null ? jenkins.proxy : null;
-            return HttpClient.getCloseableHttpClient(proxy);
+            return HttpClient.getCloseableHttpClient();
         }
 
     }

--- a/src/main/java/jenkins/plugins/slack/pipeline/SlackUserIdsFromCommittersStep.java
+++ b/src/main/java/jenkins/plugins/slack/pipeline/SlackUserIdsFromCommittersStep.java
@@ -3,7 +3,6 @@ package jenkins.plugins.slack.pipeline;
 import com.google.common.collect.ImmutableSet;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
-import hudson.ProxyConfiguration;
 import hudson.Util;
 import hudson.model.Item;
 import hudson.model.Run;
@@ -155,9 +154,7 @@ public class SlackUserIdsFromCommittersStep extends Step {
         }
 
         protected CloseableHttpClient getHttpClient() {
-            final Jenkins jenkins = Jenkins.getInstanceOrNull();
-            final ProxyConfiguration proxy = jenkins != null ? jenkins.proxy : null;
-            return HttpClient.getCloseableHttpClient(proxy);
+            return HttpClient.getCloseableHttpClient();
         }
 
     }

--- a/src/test/java/jenkins/plugins/slack/SlackApiTLSTest.java
+++ b/src/test/java/jenkins/plugins/slack/SlackApiTLSTest.java
@@ -16,7 +16,7 @@ public class SlackApiTLSTest {
 
     @Test
     public void connectToAPI() {
-        try (CloseableHttpClient httpClient = HttpClient.getCloseableHttpClient(null)) {
+        try (CloseableHttpClient httpClient = HttpClient.getCloseableHttpClient()) {
             HttpPost post = new HttpPost(SLACK_API_TEST);
             post.setHeader("Content-Type", "application/json; charset=utf-8");
             try (CloseableHttpResponse response = httpClient.execute(post)) {


### PR DESCRIPTION
### Detail

Hi, team.

I was just wondering proxy configure part on this plugin, so I explore some codes, and I saw some redundancy.
The real proxy config is set in `HttpClient.java`. And `HttpClient.getCloseableHttpClient` receive `ProxyConfiguration` parameter explicitly, so all other codes who use that method need to get proxy configuration at Jenkins instance.
So I remove the parameter in `getCloseableHttpClient`, and get Jenkins's proxy configuration inside the method.

Thanks.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
