### PR TITLE
Build really fails when failOnError set to true

### DIFF
--- a/src/main/java/jenkins/plugins/slack/workflow/SlackSendStep.java
+++ b/src/main/java/jenkins/plugins/slack/workflow/SlackSendStep.java
@@ -7,6 +7,7 @@ import hudson.AbortException;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.Item;
+import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.util.ListBoxModel;
@@ -361,6 +362,10 @@ public class SlackSendStep extends Step {
             } else {
                 listener.error(Messages
                         .notificationFailedWithException(new IllegalArgumentException("No message, attachments or blocks provided")));
+                if (step.isFailOnError()) {
+                    run.setResult(Result.FAILURE);
+                    throw new AbortException("No message, attachments or blocks provided");
+                }
                 return null;
             }
             SlackResponse response = null;
@@ -373,6 +378,7 @@ public class SlackSendStep extends Step {
                     } catch (org.json.JSONException ex) {
                         listener.error(Messages.failedToParseSlackResponse(responseString));
                         if (step.failOnError) {
+                            run.setResult(Result.FAILURE);
                             throw ex;
                         }
                     }
@@ -380,6 +386,7 @@ public class SlackSendStep extends Step {
                     return new SlackResponse(slackService);
                 }
             } else if (step.failOnError) {
+                run.setResult(Result.FAILURE);
                 if (responseString != null) {
                     throw new AbortException(Messages.notificationFailedWithException(responseString));
                 }

--- a/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepIntegrationTest.java
+++ b/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepIntegrationTest.java
@@ -50,4 +50,12 @@ public class SlackSendStepIntegrationTest {
         //everything should come from step configuration
         jenkinsRule.assertLogContains(Messages.notificationFailed(), run);
     }
+
+    @Test
+    public void test_fail_on_missing_message() throws Exception {
+        WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "workflow");
+        //with a null message
+        job.setDefinition(new CpsFlowDefinition("slackSend(message: null, baseUrl: 'baseUrl', teamDomain: 'teamDomain', token: 'token', tokenCredentialId: 'tokenCredentialId', channel: '#channel', color: 'good', failOnError: true);", true));
+        jenkinsRule.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0).get());
+    }
 }


### PR DESCRIPTION
The changes rely on the failOnError flag to mark the Run as failed. 

fixes #818

I'm opened to suggestions (missing tests case, better implementation...)

### Testing done
I tested the flag on two different cases: one where the message is null, one where the slack channel does not exist. 
Also one unit test has been added.

Testing environment: Jenkins 2.414.2 (running through Docker) 


```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
