### PR TITLE
Fix cleanChannelName() to return extracted `channel` even if channelName doesn't have `#` prefix

### DIFF
--- a/src/main/java/jenkins/plugins/slack/pipeline/SlackUploadFileStep.java
+++ b/src/main/java/jenkins/plugins/slack/pipeline/SlackUploadFileStep.java
@@ -188,9 +188,10 @@ public class SlackUploadFileStep extends Step {
         String channel = channelName;
         if (splitForThread.length == 2) {
             channel = splitForThread[0];
-        }
-        if (channel.startsWith("#")) {
-            return channel.substring(1);
+            if (channel.startsWith("#")) {
+                return channel.substring(1);
+            }
+            return channel;
         }
         return channelName;
     }


### PR DESCRIPTION
This patch fixes `cleanChannelName()` to return extracted `channel` even if `channelName` doesn't have `#` prefix.

cf. https://github.com/jenkinsci/slack-plugin/pull/965

### Testing done

The code was packaged by `mvn package` and passed existing tests. The resulting hpi was installed on a jenkins server (version 2.460) and was confirmed to run correctly.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
