### PR TITLE
Modify `getChannelId` and `convertChannelNameToId` for efficient channel ID retrieval

### DIFF
--- a/src/main/java/jenkins/plugins/slack/cache/SlackChannelIdCache.java
+++ b/src/main/java/jenkins/plugins/slack/cache/SlackChannelIdCache.java
@@ -73,6 +73,9 @@ public class SlackChannelIdCache {
     }
 
     public static String getChannelId(String botUserToken, String channelName) throws ExecutionException, InterruptedException, AbortException {
+        if (channelName.matches("^(C[A-Z0-9]{8}|G[A-Z0-9]{10}||D[A-Z0-9]{8})$")) {
+            return channelName;
+        }
         Map<String, String> channelNameToIdMap = CHANNEL_METADATA_CACHE.get(botUserToken);
         String channelId = channelNameToIdMap.get(channelName);
 


### PR DESCRIPTION
With the latest plugin ( https://github.com/jenkinsci/slack-plugin/releases/tag/715.v1cfed1b_9c63c ), the following `slackUploadFile()` cannot finish in my environment, which has roughly 5300 public/private channels. `slackUploadFile()` internally causes `Rate limited by Slack, retrying in 30000ms` many times.

```groovy
pipeline {
    agent {
        node {
            label 'master'
        }
    }
    stages {
        stage('send') {
            steps {
                script {
                    sh 'echo hello > hello.txt'
                    slackUploadFile(channel: 'GXXXXXXXXXX', filePath: 'hello.txt', initialComment: "test")
                }
            }
        }
    }
}
```

If a channel is specified by its ID, `getChannelId()` can avoid many `conversations.list` calls. 894f6ead46a7308e9535b75e2da1c459fb4f09cf allows `getChannelId()` to return immediately if `channelName` matches the pattern of ID.

I also experimentally found that `conversations.list` with `types=public_channel,private_channel` requires much more API calls than `conversations.list` with two separate `types=public_channel` and `types=private_channel`. 48d915242234f74ac046fd866d066130f359166d splits `convertChannelNameToId()` into two methods, one for `types=public_channel` and another for `types=private_channel`. A new parameter `limit=999` is also added to reduce API calls further.

### Testing done

The code was packaged by `mvn package` and passed existing tests. The resulting hpi was installed on a jenkins server (version 2.460) and was confirmed to run correctly.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
