### PR TITLE
Migrate tests to JUnit5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>5.5</version>
+        <version>5.6</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,11 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/test/java/jenkins/plugins/slack/MessageBuilderEscapeTest.java
+++ b/src/test/java/jenkins/plugins/slack/MessageBuilderEscapeTest.java
@@ -3,19 +3,19 @@ package jenkins.plugins.slack;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import jenkins.plugins.slack.logging.BuildAwareLogger;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class MessageBuilderEscapeTest {
+class MessageBuilderEscapeTest {
 
     private static ActiveNotifier.MessageBuilder messageBuilder;
 
-    @BeforeClass
-    public static void setupMessageBuilder() {
+    @BeforeAll
+    static void setupMessageBuilder() {
         AbstractBuild build = mock(AbstractBuild.class);
         AbstractProject project = mock(AbstractProject.class);
         AbstractProject job = mock(AbstractProject.class);
@@ -32,7 +32,7 @@ public class MessageBuilderEscapeTest {
     }
 
     @Test
-    public void testEscapeAnchor() {
+    void testEscapeAnchor() {
         String input = "<a href='target'>test</a>";
         String expected = "<'target'|test>";
         String escaped = messageBuilder.escape(input);
@@ -40,7 +40,7 @@ public class MessageBuilderEscapeTest {
     }
 
     @Test
-    public void testEscapePercent() {
+    void testEscapePercent() {
         String input = "hello % world";
         String expected = "hello % world";
         String escaped = messageBuilder.escape(input);
@@ -48,7 +48,7 @@ public class MessageBuilderEscapeTest {
     }
 
     @Test
-    public void testEscapeBraces() {
+    void testEscapeBraces() {
         String input = "something { is } odd";
         String expected = "something { is } odd";
         String escaped = messageBuilder.escape(input);
@@ -56,7 +56,7 @@ public class MessageBuilderEscapeTest {
     }
 
     @Test
-    public void testEscapeBracesInLink() {
+    void testEscapeBracesInLink() {
         String input = "<a href='target'>test { case }</a>";
         String expected = "<'target'|test { case }>";
         String escaped = messageBuilder.escape(input);

--- a/src/test/java/jenkins/plugins/slack/SlackApiTLSTest.java
+++ b/src/test/java/jenkins/plugins/slack/SlackApiTLSTest.java
@@ -4,17 +4,17 @@ import java.io.IOException;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class SlackApiTLSTest {
+class SlackApiTLSTest {
 
-    public static final String SLACK_API_TEST = "https://slack.com/api/api.test";
+    private static final String SLACK_API_TEST = "https://slack.com/api/api.test";
 
     @Test
-    public void connectToAPI() {
+    void connectToAPI() {
         try (CloseableHttpClient httpClient = HttpClient.getCloseableHttpClient(null)) {
             HttpPost post = new HttpPost(SLACK_API_TEST);
             post.setHeader("Content-Type", "application/json; charset=utf-8");

--- a/src/test/java/jenkins/plugins/slack/SlackNotifierUnitTest.java
+++ b/src/test/java/jenkins/plugins/slack/SlackNotifierUnitTest.java
@@ -1,37 +1,37 @@
 package jenkins.plugins.slack;
 
 import hudson.util.FormValidation;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class SlackNotifierUnitTest {
+class SlackNotifierUnitTest {
     private SlackNotifier slackNotifier = new SlackNotifier(CommitInfoChoice.AUTHORS);
     private SlackNotifierStub.DescriptorImplStub descriptor;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         descriptor = new SlackNotifierStub.DescriptorImplStub();
     }
 
     @Test
-    public void isAnyCustomMessagePopulatedReturnsFalseWhenNonePopulated() {
+    void isAnyCustomMessagePopulatedReturnsFalseWhenNonePopulated() {
         assertFalse(slackNotifier.isAnyCustomMessagePopulated());
     }
 
     @Test
-    public void isAnyCustomMessagePopulatedReturnsTrueWhenOnePopulated() {
+    void isAnyCustomMessagePopulatedReturnsTrueWhenOnePopulated() {
         slackNotifier.setCustomMessage("hi");
 
         assertTrue(slackNotifier.isAnyCustomMessagePopulated());
     }
 
     @Test
-    public void isAnyCustomMessagePopulatedReturnsTrueWhenMultiplePopulated() {
+    void isAnyCustomMessagePopulatedReturnsTrueWhenMultiplePopulated() {
         slackNotifier.setCustomMessage("hi");
         slackNotifier.setCustomMessageFailure("hii");
 
@@ -39,35 +39,35 @@ public class SlackNotifierUnitTest {
     }
 
     @Test
-    public void doCheckBaseUrl_emptyIsValid() {
+    void doCheckBaseUrl_emptyIsValid() {
         FormValidation formValidation = descriptor.doCheckBaseUrl("", null);
 
         assertThat(formValidation.kind, is(FormValidation.Kind.OK));
     }
 
     @Test
-    public void doCheckBaseUrl_setIsValid() {
+    void doCheckBaseUrl_setIsValid() {
         FormValidation formValidation = descriptor.doCheckBaseUrl("", null);
 
         assertThat(formValidation.kind, is(FormValidation.Kind.OK));
     }
 
     @Test
-    public void doCheckBaseUrl_baseUrlAndTeamDomainSet_is_invalid() {
+    void doCheckBaseUrl_baseUrlAndTeamDomainSet_is_invalid() {
         FormValidation formValidation = descriptor.doCheckBaseUrl("a", "a");
 
         assertThat(formValidation.kind, is(FormValidation.Kind.ERROR));
     }
 
     @Test
-    public void doCheckBaseUrl_teamDomain_only_set_is_valid() {
+    void doCheckBaseUrl_teamDomain_only_set_is_valid() {
         FormValidation formValidation = descriptor.doCheckBaseUrl(null, "a");
 
         assertThat(formValidation.kind, is(FormValidation.Kind.OK));
     }
 
     @Test
-    public void doCheckBaseUrl_including_jenkins_ci_hook_is_invalid() {
+    void doCheckBaseUrl_including_jenkins_ci_hook_is_invalid() {
         FormValidation formValidation = descriptor.doCheckBaseUrl("https://jenkins-slack-plugin-testing.slack.com/services/hooks/jenkins-ci", null);
 
         assertThat(formValidation.kind, is(FormValidation.Kind.ERROR));

--- a/src/test/java/jenkins/plugins/slack/StandardSlackServiceTest.java
+++ b/src/test/java/jenkins/plugins/slack/StandardSlackServiceTest.java
@@ -2,18 +2,18 @@ package jenkins.plugins.slack;
 
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClientStub;
 import org.apache.hc.core5.http.HttpStatus;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class StandardSlackServiceTest {
+class StandardSlackServiceTest {
     /**
      * Use a valid host, but an invalid team domain
      */
     @Test
-    public void invalidTeamDomainShouldFail() {
+    void invalidTeamDomainShouldFail() {
         StandardSlackService service = new StandardSlackService(
                 StandardSlackService.builder()
                         .withBaseUrl("")
@@ -26,7 +26,7 @@ public class StandardSlackServiceTest {
     }
 
     @Test
-    public void badConfigurationWillBeCorrected() {
+    void badConfigurationWillBeCorrected() {
         StandardSlackService service = new StandardSlackService(
                 StandardSlackService.builder()
                         .withBaseUrl("https://example.slack.com/services/hooks/jenkins-ci")
@@ -42,7 +42,7 @@ public class StandardSlackServiceTest {
      * Use a valid team domain, but a bad token
      */
     @Test
-    public void invalidTokenShouldFail() {
+    void invalidTokenShouldFail() {
         StandardSlackService service = new StandardSlackService(
                 StandardSlackService.builder()
                         .withBaseUrl("")
@@ -55,7 +55,7 @@ public class StandardSlackServiceTest {
     }
 
     @Test
-    public void publishToASingleRoomSendsASingleMessage() {
+    void publishToASingleRoomSendsASingleMessage() {
         StandardSlackServiceStub service = new StandardSlackServiceStub(
                 StandardSlackService.builder()
                         .withBaseUrl("")
@@ -70,7 +70,7 @@ public class StandardSlackServiceTest {
     }
 
     @Test
-    public void publishToMultipleRoomsSendsAMessageToEveryRoom() {
+    void publishToMultipleRoomsSendsAMessageToEveryRoom() {
         StandardSlackServiceStub service = new StandardSlackServiceStub(
                 StandardSlackService.builder()
                         .withBaseUrl("")
@@ -85,7 +85,7 @@ public class StandardSlackServiceTest {
     }
 
     @Test
-    public void successfulPublishToASingleRoomReturnsTrue() {
+    void successfulPublishToASingleRoomReturnsTrue() {
         StandardSlackServiceStub service = new StandardSlackServiceStub(
                 StandardSlackService.builder()
                         .withBaseUrl("")
@@ -101,7 +101,7 @@ public class StandardSlackServiceTest {
 
 
     @Test
-    public void successfulPublishToSingleRoomWithProvidedTokenReturnsTrue() {
+    void successfulPublishToSingleRoomWithProvidedTokenReturnsTrue() {
         StandardSlackServiceStub service = new StandardSlackServiceStub(
                 StandardSlackService.builder()
                         .withBaseUrl("")
@@ -116,7 +116,7 @@ public class StandardSlackServiceTest {
     }
 
     @Test
-    public void successfulPublishToMultipleRoomsReturnsTrue() {
+    void successfulPublishToMultipleRoomsReturnsTrue() {
         StandardSlackServiceStub service = new StandardSlackServiceStub(
                 StandardSlackService.builder()
                         .withBaseUrl("")
@@ -131,7 +131,7 @@ public class StandardSlackServiceTest {
     }
 
     @Test
-    public void failedPublishToASingleRoomReturnsFalse() {
+    void failedPublishToASingleRoomReturnsFalse() {
         StandardSlackServiceStub service = new StandardSlackServiceStub(
                 StandardSlackService.builder()
                         .withBaseUrl("")
@@ -146,7 +146,7 @@ public class StandardSlackServiceTest {
     }
 
     @Test
-    public void singleFailedPublishToMultipleRoomsReturnsFalse() {
+    void singleFailedPublishToMultipleRoomsReturnsFalse() {
         StandardSlackServiceStub service = new StandardSlackServiceStub(
                 StandardSlackService.builder()
                         .withBaseUrl("")
@@ -162,7 +162,7 @@ public class StandardSlackServiceTest {
     }
 
     @Test
-    public void publishToEmptyRoomReturnsTrue() {
+    void publishToEmptyRoomReturnsTrue() {
         StandardSlackServiceStub service = new StandardSlackServiceStub(
                 StandardSlackService.builder()
                         .withBaseUrl("")
@@ -178,7 +178,7 @@ public class StandardSlackServiceTest {
 
 
     @Test
-    public void sendAsBotUserReturnsTrue() {
+    void sendAsBotUserReturnsTrue() {
         StandardSlackServiceStub service = new StandardSlackServiceStub(
                 StandardSlackService.builder()
                         .withBaseUrl("")
@@ -193,7 +193,7 @@ public class StandardSlackServiceTest {
     }
 
     @Test
-    public void sendAsBotUserInThreadReturnsTrue() {
+    void sendAsBotUserInThreadReturnsTrue() {
         StandardSlackServiceStub service = new StandardSlackServiceStub(
                 StandardSlackService.builder()
                         .withBaseUrl("")
@@ -208,7 +208,7 @@ public class StandardSlackServiceTest {
     }
 
     @Test
-    public void sendAsBotUserWithUpdate() {
+    void sendAsBotUserWithUpdate() {
         StandardSlackServiceStub service = new StandardSlackServiceStub(
                 StandardSlackService.builder()
                         .withBaseUrl("")
@@ -223,7 +223,7 @@ public class StandardSlackServiceTest {
     }
 
     @Test
-    public void populatedTokenIsUsed() {
+    void populatedTokenIsUsed() {
         final String populatedToken = "secret-text";
         StandardSlackServiceStub service = new StandardSlackServiceStub(
                 StandardSlackService.builder()
@@ -240,7 +240,7 @@ public class StandardSlackServiceTest {
     }
 
     @Test
-    public void iconEmojiAndBotUserReturnsTrue() {
+    void iconEmojiAndBotUserReturnsTrue() {
         StandardSlackServiceStub service = new StandardSlackServiceStub(
                 StandardSlackService.builder()
                         .withBaseUrl("")
@@ -256,7 +256,7 @@ public class StandardSlackServiceTest {
     }
 
     @Test
-    public void usernameAndBotUserReturnsTrue() {
+    void usernameAndBotUserReturnsTrue() {
         StandardSlackServiceStub service = new StandardSlackServiceStub(
                 StandardSlackService.builder()
                         .withBaseUrl("")
@@ -272,7 +272,7 @@ public class StandardSlackServiceTest {
     }
 
     @Test
-    public void iconEmojiAndNotBotUserReturnsTrue() {
+    void iconEmojiAndNotBotUserReturnsTrue() {
         StandardSlackServiceStub service = new StandardSlackServiceStub(
                 StandardSlackService.builder()
                         .withBaseUrl("")
@@ -288,7 +288,7 @@ public class StandardSlackServiceTest {
     }
 
     @Test
-    public void usernameAndNotBotUserReturnsTrue() {
+    void usernameAndNotBotUserReturnsTrue() {
         StandardSlackServiceStub service = new StandardSlackServiceStub(
                 StandardSlackService.builder()
                         .withBaseUrl("")
@@ -304,7 +304,7 @@ public class StandardSlackServiceTest {
     }
 
     @Test
-    public void shouldRemoveAReaction() {
+    void shouldRemoveAReaction() {
         StandardSlackServiceStub service = new StandardSlackServiceStub(
                 StandardSlackService.builder()
                         .withBaseUrl("")

--- a/src/test/java/jenkins/plugins/slack/config/GlobalCredentialMigratorTest.java
+++ b/src/test/java/jenkins/plugins/slack/config/GlobalCredentialMigratorTest.java
@@ -11,43 +11,44 @@ import jenkins.model.Jenkins;
 import jenkins.plugins.slack.Messages;
 import jenkins.plugins.slack.SlackNotifier;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.jvnet.hudson.test.recipes.LocalData;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @SuppressWarnings("deprecation")
-public class GlobalCredentialMigratorTest {
+@WithJenkins
+class GlobalCredentialMigratorTest {
 
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
-
+    @SuppressWarnings({"unused", "FieldCanBeLocal"})
+    private JenkinsRule j;
     private SlackNotifier.DescriptorImpl descriptor;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup(JenkinsRule j) {
+        this.j = j;
         descriptor = ExtensionList.lookupSingleton(SlackNotifier.DescriptorImpl.class);
     }
 
     @Test
     @LocalData
-    public void noToken() {
+    void noToken() {
         assertNull(Util.fixEmpty(descriptor.getToken()));
-        assertEquals(descriptor.getTokenCredentialId(), "abcdef");
+        assertEquals("abcdef", descriptor.getTokenCredentialId());
     }
 
     @Test
     @LocalData
-    public void withToken() {
+    void withToken() {
         assertNull(Util.fixEmpty(descriptor.getToken()));
         String tokenCredentialId = descriptor.getTokenCredentialId();
 
         StringCredentials stringCredentials = lookupCredentials(tokenCredentialId);
-        assertEquals(stringCredentials.getDescription(), Messages.migratedCredentialDescription());
+        assertEquals(Messages.migratedCredentialDescription(), stringCredentials.getDescription());
     }
 
     private StringCredentials lookupCredentials(String credentialId) {

--- a/src/test/java/jenkins/plugins/slack/decisions/ContextTest.java
+++ b/src/test/java/jenkins/plugins/slack/decisions/ContextTest.java
@@ -2,28 +2,24 @@ package jenkins.plugins.slack.decisions;
 
 import hudson.model.AbstractBuild;
 import hudson.model.Result;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.BDDMockito.given;
 
-public class ContextTest {
+@ExtendWith(MockitoExtension.class)
+class ContextTest {
     @Mock
     private AbstractBuild<?, ?> previous;
     @Mock
     private AbstractBuild<?, ?> current;
 
-    @Before
-    public void setup() {
-        MockitoAnnotations.initMocks(this);
-    }
-
     @Test
-    public void shouldReturnSuccessIfPreviousBuildNull() {
+    void shouldReturnSuccessIfPreviousBuildNull() {
         Context context = new Context(current, null);
         Result expected = Result.SUCCESS;
 
@@ -33,7 +29,7 @@ public class ContextTest {
     }
 
     @Test
-    public void shouldReturnSuccessIfPreviousResultNull() {
+    void shouldReturnSuccessIfPreviousResultNull() {
         given(previous.getResult()).willReturn(null);
         Context context = new Context(current, previous);
         Result expected = Result.SUCCESS;
@@ -44,7 +40,7 @@ public class ContextTest {
     }
 
     @Test
-    public void shouldReturnPreviousResultIfPresent() {
+    void shouldReturnPreviousResultIfPresent() {
         Result expected = Result.UNSTABLE;
         given(previous.getResult()).willReturn(expected);
         Context context = new Context(current, previous);
@@ -55,7 +51,7 @@ public class ContextTest {
     }
 
     @Test
-    public void shouldReturnCurrentResultIfPresent() {
+    void shouldReturnCurrentResultIfPresent() {
         Result expected = Result.NOT_BUILT;
         given(current.getResult()).willReturn(expected);
         Context context = new Context(current, previous);
@@ -66,7 +62,7 @@ public class ContextTest {
     }
 
     @Test
-    public void shouldReturnNullIfCurrentBuildNull() {
+    void shouldReturnNullIfCurrentBuildNull() {
         Context context = new Context(null, previous);
 
         Result actual = context.currentResult();
@@ -75,7 +71,7 @@ public class ContextTest {
     }
 
     @Test
-    public void shouldReturnNullIfCurrentResultNull() {
+    void shouldReturnNullIfCurrentResultNull() {
         given(current.getResult()).willReturn(null);
         Context context = new Context(current, previous);
 

--- a/src/test/java/jenkins/plugins/slack/decisions/NotificationConditionsTest.java
+++ b/src/test/java/jenkins/plugins/slack/decisions/NotificationConditionsTest.java
@@ -1,14 +1,14 @@
 package jenkins.plugins.slack.decisions;
 
 import java.util.Arrays;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class NotificationConditionsTest {
+class NotificationConditionsTest {
 
     @Test
-    public void shouldMatchIfAnyConditionMatches() {
+    void shouldMatchIfAnyConditionMatches() {
         NotificationConditions conditions = new NotificationConditions(Arrays.asList(
                 p -> false,
                 p -> false,

--- a/src/test/java/jenkins/plugins/slack/decisions/OnBackToNormalTest.java
+++ b/src/test/java/jenkins/plugins/slack/decisions/OnBackToNormalTest.java
@@ -2,29 +2,25 @@ package jenkins.plugins.slack.decisions;
 
 import hudson.model.Result;
 import jenkins.plugins.slack.logging.BuildAwareLogger;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
-public class OnBackToNormalTest {
+@ExtendWith(MockitoExtension.class)
+class OnBackToNormalTest {
     @Mock
     private Context context;
     @Mock
     private BuildAwareLogger log;
     private OnBackToNormal subject = new OnBackToNormal(null, log);
 
-    @Before
-    public void setup() {
-        MockitoAnnotations.initMocks(this);
-    }
-
     @Test
-    public void shouldMeetConditionIfPreviousFailureIsNowSuccess() {
+    void shouldMeetConditionIfPreviousFailureIsNowSuccess() {
         given(context.previousResultOrSuccess()).willReturn(Result.FAILURE);
         given(context.currentResult()).willReturn(Result.SUCCESS);
 
@@ -34,7 +30,7 @@ public class OnBackToNormalTest {
     }
 
     @Test
-    public void shouldMeetConditionIfPreviousUnstableIsNowSuccess() {
+    void shouldMeetConditionIfPreviousUnstableIsNowSuccess() {
         given(context.previousResultOrSuccess()).willReturn(Result.UNSTABLE);
         given(context.currentResult()).willReturn(Result.SUCCESS);
 
@@ -44,7 +40,7 @@ public class OnBackToNormalTest {
     }
 
     @Test
-    public void shouldNotMeetConditionIfCurrentIsNotSuccess() {
+    void shouldNotMeetConditionIfCurrentIsNotSuccess() {
         given(context.previousResultOrSuccess()).willReturn(Result.FAILURE);
         given(context.currentResult()).willReturn(Result.FAILURE);
 
@@ -54,7 +50,7 @@ public class OnBackToNormalTest {
     }
 
     @Test
-    public void shouldNotMeetConditionIfPreviousIsSuccess() {
+    void shouldNotMeetConditionIfPreviousIsSuccess() {
         given(context.previousResultOrSuccess()).willReturn(Result.FAILURE);
         given(context.currentResult()).willReturn(Result.FAILURE);
 

--- a/src/test/java/jenkins/plugins/slack/decisions/OnEveryFailureTest.java
+++ b/src/test/java/jenkins/plugins/slack/decisions/OnEveryFailureTest.java
@@ -2,29 +2,25 @@ package jenkins.plugins.slack.decisions;
 
 import hudson.model.Result;
 import jenkins.plugins.slack.logging.BuildAwareLogger;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
-public class OnEveryFailureTest {
+@ExtendWith(MockitoExtension.class)
+class OnEveryFailureTest {
     @Mock
     private Context context;
     @Mock
     private BuildAwareLogger log;
     private OnEveryFailure condition = new OnEveryFailure(null, log);
 
-    @Before
-    public void setup() {
-        MockitoAnnotations.initMocks(this);
-    }
-
     @Test
-    public void shouldMeetConditionIfCurrentIsFailure() {
+    void shouldMeetConditionIfCurrentIsFailure() {
         given(context.currentResult()).willReturn(Result.FAILURE);
 
         boolean actual = condition.isMetBy(context);
@@ -33,7 +29,7 @@ public class OnEveryFailureTest {
     }
 
     @Test
-    public void shouldNotMeetConditionIfCurrentIsUnstable() {
+    void shouldNotMeetConditionIfCurrentIsUnstable() {
         given(context.currentResult()).willReturn(Result.UNSTABLE);
 
         boolean actual = condition.isMetBy(context);

--- a/src/test/java/jenkins/plugins/slack/decisions/OnRegressionTest.java
+++ b/src/test/java/jenkins/plugins/slack/decisions/OnRegressionTest.java
@@ -3,16 +3,17 @@ package jenkins.plugins.slack.decisions;
 import hudson.model.Result;
 import hudson.tasks.junit.TestResultAction;
 import jenkins.plugins.slack.logging.BuildAwareLogger;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
-public class OnRegressionTest {
+@ExtendWith(MockitoExtension.class)
+class OnRegressionTest {
     @Mock
     private Context context;
     @Mock
@@ -24,13 +25,8 @@ public class OnRegressionTest {
 
     private OnRegression condition = new OnRegression(null, log);
 
-    @Before
-    public void setup() {
-        MockitoAnnotations.initMocks(this);
-    }
-
     @Test
-    public void shouldMeetConditionIfCurrentIsWorseThanPrevious() {
+    void shouldMeetConditionIfCurrentIsWorseThanPrevious() {
         given(context.currentResultOrSuccess()).willReturn(Result.FAILURE);
         given(context.previousResultOrSuccess()).willReturn(Result.SUCCESS);
 
@@ -40,7 +36,7 @@ public class OnRegressionTest {
     }
 
     @Test
-    public void shouldNotMeetConditionIfCurrentIsBetterThanPrevious() {
+    void shouldNotMeetConditionIfCurrentIsBetterThanPrevious() {
         given(context.currentResultOrSuccess()).willReturn(Result.SUCCESS);
         given(context.previousResultOrSuccess()).willReturn(Result.FAILURE);
 
@@ -50,7 +46,7 @@ public class OnRegressionTest {
     }
 
     @Test
-    public void shouldMeetConditionIfCurrentIsHasMoreTestFailuresThanPrevious() {
+    void shouldMeetConditionIfCurrentIsHasMoreTestFailuresThanPrevious() {
         given(context.currentResultOrSuccess()).willReturn(Result.UNSTABLE);
         given(context.previousResultOrSuccess()).willReturn(Result.UNSTABLE);
         given(context.getPreviousTestResult()).willReturn(previousTestResult);
@@ -64,7 +60,7 @@ public class OnRegressionTest {
     }
 
     @Test
-    public void shouldNotMeetConditionIfCurrentIsHasFewerTestFailuresThanPrevious() {
+    void shouldNotMeetConditionIfCurrentIsHasFewerTestFailuresThanPrevious() {
         given(context.currentResultOrSuccess()).willReturn(Result.UNSTABLE);
         given(context.previousResultOrSuccess()).willReturn(Result.UNSTABLE);
         given(context.getPreviousTestResult()).willReturn(previousTestResult);

--- a/src/test/java/jenkins/plugins/slack/decisions/OnRepeatedFailureTest.java
+++ b/src/test/java/jenkins/plugins/slack/decisions/OnRepeatedFailureTest.java
@@ -2,29 +2,25 @@ package jenkins.plugins.slack.decisions;
 
 import hudson.model.Result;
 import jenkins.plugins.slack.logging.BuildAwareLogger;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
-public class OnRepeatedFailureTest {
-    @Mock
+@ExtendWith(MockitoExtension.class)
+class OnRepeatedFailureTest {
+    @Mock(strictness = Mock.Strictness.LENIENT)
     private Context context;
     @Mock
     private BuildAwareLogger log;
     private OnRepeatedFailure condition = new OnRepeatedFailure(null, log);
 
-    @Before
-    public void setup() {
-        MockitoAnnotations.initMocks(this);
-    }
-
     @Test
-    public void shouldMeetConditionIfCurrentAndPreviousAreFailures() {
+    void shouldMeetConditionIfCurrentAndPreviousAreFailures() {
         given(context.previousResultOrSuccess()).willReturn(Result.FAILURE);
         given(context.currentResult()).willReturn(Result.FAILURE);
 
@@ -34,7 +30,7 @@ public class OnRepeatedFailureTest {
     }
 
     @Test
-    public void shouldNotMeetConditionIfCurrentIsUnstable() {
+    void shouldNotMeetConditionIfCurrentIsUnstable() {
         given(context.previousResultOrSuccess()).willReturn(Result.FAILURE);
         given(context.currentResult()).willReturn(Result.UNSTABLE);
 
@@ -44,7 +40,7 @@ public class OnRepeatedFailureTest {
     }
 
     @Test
-    public void shouldNotMeetConditionIfPreviousIsUnstable() {
+    void shouldNotMeetConditionIfPreviousIsUnstable() {
         given(context.previousResultOrSuccess()).willReturn(Result.UNSTABLE);
         given(context.currentResult()).willReturn(Result.FAILURE);
 

--- a/src/test/java/jenkins/plugins/slack/decisions/OnSingleFailureTest.java
+++ b/src/test/java/jenkins/plugins/slack/decisions/OnSingleFailureTest.java
@@ -2,29 +2,25 @@ package jenkins.plugins.slack.decisions;
 
 import hudson.model.Result;
 import jenkins.plugins.slack.logging.BuildAwareLogger;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
-public class OnSingleFailureTest {
-    @Mock
+@ExtendWith(MockitoExtension.class)
+class OnSingleFailureTest {
+    @Mock(strictness = Mock.Strictness.LENIENT)
     private Context context;
     @Mock
     private BuildAwareLogger log;
     private OnSingleFailure condition = new OnSingleFailure(null, log);
 
-    @Before
-    public void setup() {
-        MockitoAnnotations.initMocks(this);
-    }
-
     @Test
-    public void shouldMeetConditionIfCurrentIsFailureAndPreviousIsUnstable() {
+    void shouldMeetConditionIfCurrentIsFailureAndPreviousIsUnstable() {
         given(context.previousResultOrSuccess()).willReturn(Result.UNSTABLE);
         given(context.currentResult()).willReturn(Result.FAILURE);
 
@@ -34,7 +30,7 @@ public class OnSingleFailureTest {
     }
 
     @Test
-    public void shouldNotMeetConditionIfCurrentIsFailureAndPreviousIsFailure() {
+    void shouldNotMeetConditionIfCurrentIsFailureAndPreviousIsFailure() {
         given(context.previousResultOrSuccess()).willReturn(Result.FAILURE);
         given(context.currentResult()).willReturn(Result.FAILURE);
 
@@ -44,7 +40,7 @@ public class OnSingleFailureTest {
     }
 
     @Test
-    public void shouldNotMeetConditionIfCurrentIsSuccess() {
+    void shouldNotMeetConditionIfCurrentIsSuccess() {
         given(context.previousResultOrSuccess()).willReturn(Result.FAILURE);
         given(context.currentResult()).willReturn(Result.SUCCESS);
 

--- a/src/test/java/jenkins/plugins/slack/jcasc/ConfigurationAsCodeTest.java
+++ b/src/test/java/jenkins/plugins/slack/jcasc/ConfigurationAsCodeTest.java
@@ -5,25 +5,23 @@ import io.jenkins.plugins.casc.ConfigurationContext;
 import io.jenkins.plugins.casc.ConfiguratorRegistry;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
 import io.jenkins.plugins.casc.model.CNode;
 import jenkins.plugins.slack.SlackNotifier;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.jenkins.plugins.casc.misc.Util.getUnclassifiedRoot;
 import static io.jenkins.plugins.casc.misc.Util.toStringFromYamlFile;
 import static io.jenkins.plugins.casc.misc.Util.toYamlString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
+@WithJenkinsConfiguredWithCode
 public class ConfigurationAsCodeTest {
 
-    @ClassRule
-    @ConfiguredWithCode("configuration-as-code.yml")
-    public static JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
-
     @Test
-    public void should_support_configuration_as_code() {
+    @ConfiguredWithCode("configuration-as-code.yml")
+    void should_support_configuration_as_code(JenkinsConfiguredWithCodeRule j) {
         SlackNotifier.DescriptorImpl slackNotifier = ExtensionList.lookupSingleton(SlackNotifier.DescriptorImpl.class);
 
         assertThat(slackNotifier.getTeamDomain(), is("jenkins-slack-plugin"));
@@ -31,7 +29,8 @@ public class ConfigurationAsCodeTest {
     }
 
     @Test
-    public void should_support_configuration_export() throws Exception {
+    @ConfiguredWithCode("configuration-as-code.yml")
+    void should_support_configuration_export(JenkinsConfiguredWithCodeRule j) throws Exception {
         ConfiguratorRegistry registry = ConfiguratorRegistry.get();
         ConfigurationContext context = new ConfigurationContext(registry);
         CNode yourAttribute = getUnclassifiedRoot(context).get("slackNotifier");

--- a/src/test/java/jenkins/plugins/slack/logging/SlackNotificationsLoggerTest.java
+++ b/src/test/java/jenkins/plugins/slack/logging/SlackNotificationsLoggerTest.java
@@ -4,21 +4,22 @@ import hudson.model.TaskListener;
 import java.io.PrintStream;
 import java.util.function.Supplier;
 import java.util.logging.Logger;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-public class SlackNotificationsLoggerTest {
+@ExtendWith(MockitoExtension.class)
+class SlackNotificationsLoggerTest {
     @Mock
     private Logger system;
     @Mock
@@ -27,21 +28,13 @@ public class SlackNotificationsLoggerTest {
     private ArgumentCaptor<Supplier<String>> messageSupplier;
     private SlackNotificationsLogger logger;
 
-    private AutoCloseable autoCloseable;
-
-    @Before
-    public void setup() {
-        autoCloseable = MockitoAnnotations.openMocks(this);
+    @BeforeEach
+    void setup() {
         logger = new SlackNotificationsLogger(system, user);
     }
 
-    @After
-    public void fin() throws Exception {
-        autoCloseable.close();
-    }
-
     @Test
-    public void shouldOnlyWriteDebugMessagesToSystemLog() {
+    void shouldOnlyWriteDebugMessagesToSystemLog() {
         String expected = "[key] this message has number 15 within it";
 
         logger.debug("[key]", "this message has number %d %s it", 15, "within");
@@ -52,7 +45,7 @@ public class SlackNotificationsLoggerTest {
     }
 
     @Test
-    public void shouldWriteInfoMessagesToSystemAndUserLogs() {
+    void shouldWriteInfoMessagesToSystemAndUserLogs() {
         String expectedUserLog = "[Slack Notifications] a 100% useful sort of message";
         String expectedSystemLog = "[Project #17] a 100% useful sort of message";
 

--- a/src/test/java/jenkins/plugins/slack/pipeline/SlackUploadFileStepIntegrationTest.java
+++ b/src/test/java/jenkins/plugins/slack/pipeline/SlackUploadFileStepIntegrationTest.java
@@ -9,16 +9,15 @@ import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.cps.SnippetizerTester;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class SlackUploadFileStepIntegrationTest {
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class SlackUploadFileStepIntegrationTest {
 
     @Test
-    public void configRoundTrip() throws Exception {
+    void configRoundTrip(JenkinsRule j) throws Exception {
         SnippetizerTester st = new SnippetizerTester(j);
         SlackUploadFileStep step = new SlackUploadFileStep("file.txt");
         st.assertRoundTrip(step, "slackUploadFile 'file.txt'");
@@ -31,7 +30,7 @@ public class SlackUploadFileStepIntegrationTest {
     }
 
     @Test
-    public void test_run_passes() throws Exception {
+    void test_run_passes(JenkinsRule j) throws Exception {
         Jenkins jenkins = j.jenkins;
 
         SystemCredentialsProvider instance = SystemCredentialsProvider.getInstance();

--- a/src/test/java/jenkins/plugins/slack/pipeline/SlackUserIdFromEmailStepIntegrationTest.java
+++ b/src/test/java/jenkins/plugins/slack/pipeline/SlackUserIdFromEmailStepIntegrationTest.java
@@ -8,26 +8,24 @@ import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.cps.SnippetizerTester;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class SlackUserIdFromEmailStepIntegrationTest {
+@WithJenkins
+class SlackUserIdFromEmailStepIntegrationTest {
 
     private static final String EMAIL_ADDRESS = "spengler@ghostbusters.example.com";
 
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
-
     @Test
-    public void configRoundTrip() throws Exception {
+    void configRoundTrip(JenkinsRule j) throws Exception {
         SnippetizerTester st = new SnippetizerTester(j);
         SlackUserIdFromEmailStep step = new SlackUserIdFromEmailStep(EMAIL_ADDRESS);
         st.assertRoundTrip(step, "slackUserIdFromEmail '" + EMAIL_ADDRESS + "'");
     }
 
     @Test
-    public void testRunPasses() throws Exception {
+    void testRunPasses(JenkinsRule j) throws Exception {
         Jenkins jenkins = j.jenkins;
 
         SystemCredentialsProvider instance = SystemCredentialsProvider.getInstance();

--- a/src/test/java/jenkins/plugins/slack/pipeline/SlackUserIdsFromCommittersStepIntegrationTest.java
+++ b/src/test/java/jenkins/plugins/slack/pipeline/SlackUserIdsFromCommittersStepIntegrationTest.java
@@ -8,24 +8,22 @@ import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.cps.SnippetizerTester;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class SlackUserIdsFromCommittersStepIntegrationTest {
-
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class SlackUserIdsFromCommittersStepIntegrationTest {
 
     @Test
-    public void configRoundTrip() throws Exception {
+    void configRoundTrip(JenkinsRule j) throws Exception {
         SnippetizerTester st = new SnippetizerTester(j);
         SlackUserIdsFromCommittersStep step = new SlackUserIdsFromCommittersStep();
         st.assertRoundTrip(step, "slackUserIdsFromCommitters()");
     }
 
     @Test
-    public void testRunPasses() throws Exception {
+    void testRunPasses(JenkinsRule j) throws Exception {
         Jenkins jenkins = j.jenkins;
 
         SystemCredentialsProvider instance = SystemCredentialsProvider.getInstance();

--- a/src/test/java/jenkins/plugins/slack/user/EmailSlackUserIdResolverTest.java
+++ b/src/test/java/jenkins/plugins/slack/user/EmailSlackUserIdResolverTest.java
@@ -38,14 +38,15 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponseStub;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.io.entity.StringEntity;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.FakeChangeLogSCM.EntryImpl;
 import org.jvnet.hudson.test.FakeChangeLogSCM.FakeChangeLogSet;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -65,20 +66,21 @@ public class EmailSlackUserIdResolverTest {
     private EmailSlackUserIdResolver resolver;
     private MailAddressResolver mailAddressResolver;
 
-    public EmailSlackUserIdResolverTest() throws IOException {
+    @BeforeAll
+    static void beforeAll() throws IOException {
         responseOKContent = readResource("lookUpByEmailResponseOK.json");
         responseErrorContent = readResource("lookUpByEmailResponseError.json");
     }
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         httpClient = new CloseableHttpClientStub();
         mailAddressResolver = getMailAddressResolver();
         resolver = getResolver(mailAddressResolver);
     }
 
     @Test
-    public void testResolveUserIdForEmailAddress() throws IOException {
+    void testResolveUserIdForEmailAddress() throws IOException {
         String userId;
 
         // Test handling of a success response from Slack
@@ -93,7 +95,7 @@ public class EmailSlackUserIdResolverTest {
     }
 
     @Test
-    public void testResolveUserIdForUser() throws Exception {
+    void testResolveUserIdForUser() throws Exception {
         // MailAddressResolver is mocked to return EMAIL_ADDRESS associated with
         // the EXPECTED_USER_ID
         httpClient.setHttpResponse(getResponseOK());
@@ -102,7 +104,7 @@ public class EmailSlackUserIdResolverTest {
     }
 
     @Test
-    public void testResolveUserIdForUserWithoutEmailAddress() throws Exception {
+    void testResolveUserIdForUserWithoutEmailAddress() throws Exception {
         mailAddressResolver = mock(MailAddressResolver.class);
         resolver = new EmailSlackUserIdResolver(AUTH_TOKEN, httpClient, Collections.singletonList(mailAddressResolver), user -> null);
         httpClient.setHttpResponse(getResponseOK());
@@ -112,7 +114,7 @@ public class EmailSlackUserIdResolverTest {
     }
 
     @Test
-    public void testResolveUserIdWithoutAuthToken() throws Exception {
+    void testResolveUserIdWithoutAuthToken() throws Exception {
         mailAddressResolver = mock(MailAddressResolver.class);
         resolver = new EmailSlackUserIdResolver(AUTH_TOKEN, httpClient, Collections.singletonList(mailAddressResolver), user -> EMAIL_ADDRESS);
         resolver.setAuthToken(null);
@@ -123,7 +125,7 @@ public class EmailSlackUserIdResolverTest {
     }
 
     @Test
-    public void testResolveUserIdForUserWithoutDefaultMailAddressResolver() throws Exception {
+    void testResolveUserIdForUserWithoutDefaultMailAddressResolver() throws Exception {
         mailAddressResolver = mock(MailAddressResolver.class);
         resolver = new EmailSlackUserIdResolver(AUTH_TOKEN, httpClient, Collections.singletonList(mailAddressResolver), null);
         httpClient.setHttpResponse(getResponseOK());
@@ -133,9 +135,9 @@ public class EmailSlackUserIdResolverTest {
     }
 
     @Test
-    public void testResolveUserIdForUserWithoutResolver() throws Exception {
+    void testResolveUserIdForUserWithoutResolver() throws Exception {
 
-        resolver = new EmailSlackUserIdResolver(AUTH_TOKEN, httpClient, null, user -> {return EMAIL_ADDRESS;});
+        resolver = new EmailSlackUserIdResolver(AUTH_TOKEN, httpClient, null, user -> EMAIL_ADDRESS);
         httpClient.setHttpResponse(getResponseOK());
 
         String userId = resolver.findOrResolveUserId(mock(User.class));
@@ -144,7 +146,7 @@ public class EmailSlackUserIdResolverTest {
     }
 
     @Test
-    public void testResolveUserIdForUserWithSlackUserProperty() {
+    void testResolveUserIdForUserWithSlackUserProperty() {
         SlackUserProperty userProperty = new SlackUserProperty();
         userProperty.setUserId(EXPECTED_USER_ID);
         User mockUser = mock(User.class);
@@ -155,7 +157,7 @@ public class EmailSlackUserIdResolverTest {
     }
 
     @Test
-    public void testResolveUserIdForChangelogSet() throws Exception {
+    void testResolveUserIdForChangelogSet() throws Exception {
         httpClient.setHttpResponse(getResponseOK());
 
         // Create a FakeChangeLogSet with a single Entry by a mocked User
@@ -184,8 +186,8 @@ public class EmailSlackUserIdResolverTest {
         assertTrue(userIdList.containsAll(expectedUserIdList));
     }
 
-    private String readResource(String resourceName) throws IOException {
-        return IOUtils.toString(this.getClass().getResourceAsStream(resourceName), StandardCharsets.UTF_8);
+    private static String readResource(String resourceName) throws IOException {
+        return IOUtils.toString(EmailSlackUserIdResolverTest.class.getResourceAsStream(resourceName), StandardCharsets.UTF_8);
     }
 
     private CloseableHttpResponse getResponse(String content) throws IOException {

--- a/src/test/java/jenkins/plugins/slack/workflow/MessageBuilderTest.java
+++ b/src/test/java/jenkins/plugins/slack/workflow/MessageBuilderTest.java
@@ -2,63 +2,44 @@ package jenkins.plugins.slack.workflow;
 
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
-import java.util.Arrays;
-import java.util.Collection;
 import jenkins.plugins.slack.ActiveNotifier;
 import jenkins.plugins.slack.TokenExpander;
 import jenkins.plugins.slack.logging.BuildAwareLogger;
-import junit.framework.TestCase;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith(Parameterized.class)
-public class MessageBuilderTest extends TestCase {
+class MessageBuilderTest {
 
-    private ActiveNotifier.MessageBuilder messageBuilder;
-    private String expectedResult;
-    private FreeStyleBuild build;
-
-
-    @Before
-    @Override
-    public void setUp() {
-        messageBuilder = new ActiveNotifier.MessageBuilder(null, build, mock(BuildAwareLogger.class), mock(TokenExpander.class));
-    }
-
-    public MessageBuilderTest(String projectDisplayName, String buildDisplayName, String expectedResult) {
-        this.build = mock(FreeStyleBuild.class);
-        FreeStyleProject project = mock(FreeStyleProject.class);
-
-        when(build.getProject()).thenReturn(project);
-        when(build.getDisplayName()).thenReturn(buildDisplayName);
-
-        when(project.getFullDisplayName()).thenReturn(projectDisplayName);
-
-        when(project.getDisplayName()).thenReturn(projectDisplayName);
-
-        this.expectedResult = expectedResult;
-
-    }
-
-    @Parameterized.Parameters
-    public static Collection businessTypeKeys() {
-        return Arrays.asList(new Object[][]{
+    static Object[][] businessTypeKeys() {
+        return new Object[][]{
                 {"", "", " -  "},
                 {"project", "#43 Started by changes from Bob", "project - #43 Started by changes from Bob "},
                 {"project", "#541 <a href=\"https://bitbucket.org/org/project/pull-request/125\">#125 Bug</a>",
                         "project - #541 <https://bitbucket.org/org/project/pull-request/125|#125 Bug> "},
                 {"project", "#541 <b>Bold Project</b>", "project - #541 &lt;b&gt;Bold Project&lt;/b&gt; "},
                 {"project", "#541 <a no-url>bob</a>", "project - #541 &lt;a no-url&gt;bob&lt;/a&gt; "}
-        });
+        };
     }
 
-    @Test
-    public void testStartMessage() {
+    @ParameterizedTest
+    @MethodSource("businessTypeKeys")
+    void testStartMessage(String projectDisplayName, String buildDisplayName, String expectedResult) {
+        FreeStyleBuild build = mock(FreeStyleBuild.class);
+        FreeStyleProject project = mock(FreeStyleProject.class);
+
+        when(build.getProject()).thenReturn(project);
+        when(build.getDisplayName()).thenReturn(buildDisplayName);
+
+        when(project.getFullDisplayName()).thenReturn(projectDisplayName);
+        when(project.getDisplayName()).thenReturn(projectDisplayName);
+
+        ActiveNotifier.MessageBuilder messageBuilder =
+                new ActiveNotifier.MessageBuilder(null, build, mock(BuildAwareLogger.class), mock(TokenExpander.class));
+
         assertEquals(expectedResult, messageBuilder.toString());
     }
 

--- a/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepIntegrationTest.java
+++ b/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepIntegrationTest.java
@@ -7,16 +7,15 @@ import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.steps.StepConfigTester;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class SlackSendStepIntegrationTest {
-    @Rule
-    public JenkinsRule jenkinsRule = new JenkinsRule();
+@WithJenkins
+class SlackSendStepIntegrationTest {
 
     @Test
-    public void configRoundTrip() throws Exception {
+    void configRoundTrip(JenkinsRule jenkinsRule) throws Exception {
         SlackSendStep step1 = new SlackSendStep();
         step1.setMessage("message");
         step1.setColor("good");
@@ -32,7 +31,7 @@ public class SlackSendStepIntegrationTest {
     }
 
     @Test
-    public void test_global_config_override() throws Exception {
+    void test_global_config_override(JenkinsRule jenkinsRule) throws Exception {
         WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "workflow");
         //just define message
         job.setDefinition(new CpsFlowDefinition("slackSend(message: 'message', baseUrl: 'baseUrl', teamDomain: 'teamDomain', token: 'token', tokenCredentialId: 'tokenCredentialId', channel: '#channel', color: 'good', iconEmoji: ':+1:', username: 'username', timestamp: '124124.12412');", true));
@@ -42,7 +41,7 @@ public class SlackSendStepIntegrationTest {
     }
 
     @Test
-    public void test_fail_on_error() throws Exception {
+    void test_fail_on_error(JenkinsRule jenkinsRule) throws Exception {
         WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "workflow");
         //just define message
         job.setDefinition(new CpsFlowDefinition("slackSend(message: 'message', baseUrl: 'baseUrl', teamDomain: 'teamDomain', token: 'token', tokenCredentialId: 'tokenCredentialId', channel: '#channel', color: 'good', failOnError: true);", true));
@@ -52,7 +51,7 @@ public class SlackSendStepIntegrationTest {
     }
 
     @Test
-    public void test_fail_on_missing_message() throws Exception {
+    void test_fail_on_missing_message(JenkinsRule jenkinsRule) throws Exception {
         WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "workflow");
         //with a null message
         job.setDefinition(new CpsFlowDefinition("slackSend(message: null, baseUrl: 'baseUrl', teamDomain: 'teamDomain', token: 'token', tokenCredentialId: 'tokenCredentialId', channel: '#channel', color: 'good', failOnError: true);", true));

--- a/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepTest.java
+++ b/src/test/java/jenkins/plugins/slack/workflow/SlackSendStepTest.java
@@ -21,16 +21,18 @@ import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.anyBoolean;
@@ -41,41 +43,38 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.openMocks;
 
 /**
  * Traditional Unit tests, allows testing null Jenkins.get()
  */
-public class SlackSendStepTest {
+@ExtendWith(MockitoExtension.class)
+class SlackSendStepTest {
 
     @Mock
     TaskListener taskListenerMock;
-    @Mock
+    @Mock(strictness = Mock.Strictness.LENIENT)
     PrintStream printStreamMock;
-    @Mock
+    @Mock(strictness = Mock.Strictness.LENIENT)
     StepContext stepContextMock;
     @Mock
     Project project;
-    @Mock
+    @Mock(strictness = Mock.Strictness.LENIENT)
     Run run;
     @Mock
     SlackService slackServiceMock;
     @Mock
     Jenkins jenkins;
-    @Mock
+    @Mock(strictness = Mock.Strictness.LENIENT)
     SlackNotifier.DescriptorImpl slackDescMock;
 
     @Mock
     Item item;
 
-    private AutoCloseable mocks;
     private MockedStatic<Jenkins> mockedJenkins;
     private MockedStatic<CredentialsObtainer> credentialsObtainerMockedStatic;
 
-    @Before
-    public void setUp() throws IOException, InterruptedException {
-        mocks = openMocks(this);
-
+    @BeforeEach
+    void setUp() throws IOException, InterruptedException {
         mock(CredentialsObtainer.class);
         when(jenkins.getDescriptorByType(SlackNotifier.DescriptorImpl.class)).thenReturn(slackDescMock);
         credentialsObtainerMockedStatic = mockStatic(CredentialsObtainer.class);
@@ -88,15 +87,14 @@ public class SlackSendStepTest {
         when(stepContextMock.get(TaskListener.class)).thenReturn(taskListenerMock);
     }
 
-    @After
-    public void fin() throws Exception {
-        mocks.close();
+    @AfterEach
+    void fin() throws Exception {
         mockedJenkins.close();
         credentialsObtainerMockedStatic.close();
     }
 
     @Test
-    public void testStepOverrides() throws Exception {
+    void testStepOverrides() throws Exception {
         final String token = "mytoken";
         SlackSendStep slackSendStep = new SlackSendStep();
         slackSendStep.setMessage("message");
@@ -138,7 +136,7 @@ public class SlackSendStepTest {
     }
 
     @Test
-    public void testStepWithAttachments() throws Exception {
+    void testStepWithAttachments() throws Exception {
         SlackSendStep step = new SlackSendStep();
         step.setMessage("message");
         step.setTokenCredentialId("tokenCredentialId");
@@ -183,7 +181,7 @@ public class SlackSendStepTest {
     }
 
     @Test
-    public void testStepWithBlocks() throws Exception {
+    void testStepWithBlocks() throws Exception {
         SlackSendStep step = new SlackSendStep();
         step.setMessage("message");
         step.setTokenCredentialId("tokenCredentialId");
@@ -234,7 +232,7 @@ public class SlackSendStepTest {
     }
 
     @Test
-    public void testStepWithAttachmentsAndBlocks() throws Exception {
+    void testStepWithAttachmentsAndBlocks() throws Exception {
         SlackSendStep step = new SlackSendStep();
         step.setMessage("message");
         step.setTokenCredentialId("tokenCredentialId");
@@ -295,7 +293,7 @@ public class SlackSendStepTest {
     }
 
     @Test
-    public void testStepWithAttachmentsAsListOfMap() throws Exception {
+    void testStepWithAttachmentsAsListOfMap() throws Exception {
         SlackSendStep step = new SlackSendStep();
         step.setMessage("message");
         step.setTokenCredentialId("tokenCredentialId");
@@ -345,7 +343,7 @@ public class SlackSendStepTest {
     }
 
     @Test
-    public void testValuesForGlobalConfig() throws Exception {
+    void testValuesForGlobalConfig() throws Exception {
         SlackSendStep step = new SlackSendStep();
         step.setMessage("message");
 
@@ -384,7 +382,7 @@ public class SlackSendStepTest {
 
 
     @Test
-    public void testCanGetItemFromRun() throws Exception {
+    void testCanGetItemFromRun() throws Exception {
         SlackSendStep step = new SlackSendStep();
         step.setMessage("message");
 
@@ -421,7 +419,7 @@ public class SlackSendStepTest {
     }
 
     @Test
-    public void testReplyBroadcast() throws Exception {
+    void testReplyBroadcast() throws Exception {
         SlackSendStep step = new SlackSendStep();
         step.setMessage("message");
         step.setReplyBroadcast(true);
@@ -460,7 +458,7 @@ public class SlackSendStepTest {
     }
 
     @Test
-    public void testSendAsText() throws Exception {
+    void testSendAsText() throws Exception {
         SlackSendStep step = new SlackSendStep();
         step.setMessage("message");
         step.setSendAsText(true);
@@ -499,7 +497,7 @@ public class SlackSendStepTest {
     }
 
     @Test
-    public void testIconEmoji() throws Exception {
+    void testIconEmoji() throws Exception {
         SlackSendStep step = new SlackSendStep();
         step.setMessage("message");
         step.setIconEmoji(":+1:");
@@ -537,7 +535,7 @@ public class SlackSendStepTest {
     }
 
     @Test
-    public void testUsername() throws Exception {
+    void testUsername() throws Exception {
         SlackSendStep step = new SlackSendStep();
         step.setMessage("message");
         step.setUsername("username");
@@ -575,7 +573,7 @@ public class SlackSendStepTest {
     }
 
     @Test
-    public void testTimestamp() throws Exception {
+    void testTimestamp() throws Exception {
         SlackSendStep step = new SlackSendStep();
         step.setMessage("message");
         step.setUsername("username");
@@ -614,7 +612,7 @@ public class SlackSendStepTest {
     }
 
     @Test
-    public void testNonNullEmptyColor() throws Exception {
+    void testNonNullEmptyColor() throws Exception {
         SlackSendStep step = new SlackSendStep();
         step.setMessage("message");
         step.setColor("");
@@ -645,7 +643,7 @@ public class SlackSendStepTest {
     }
 
     @Test
-    public void testSlackResponseObject() throws Exception {
+    void testSlackResponseObject() throws Exception {
         SlackSendStep step = new SlackSendStep();
         step.setMessage("message");
         step.setToken("token");
@@ -691,7 +689,7 @@ public class SlackSendStepTest {
     }
 
     @Test
-    public void testSlackResponseObjectNullNonBotUser() throws Exception {
+    void testSlackResponseObjectNullNonBotUser() throws Exception {
         SlackSendStep step = new SlackSendStep();
         step.setMessage("message");
         step.setToken("token");


### PR DESCRIPTION
This PR aims to migrate all tests to JUnit5. Changes include:

* Migrate annotations and imports
* Migrate assertions
* Migrate MockitoAnnotations.initMocks to Extension
* Remove public visibility for test classes and methods
* Minor clean up

I am well aware that this is a quite large changeset however I hope that there is still interest in this PR and it will be reviewed.
If there are any questions, please do not hesitate to ping me.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub 
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
