### PR TITLE
Update renovate to use Jenkins' parent config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,13 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
-    ":semanticCommitsDisabled",
+    "github>jenkinsci/renovate-config",
     "schedule:earlyMondays"
   ],
-  "automerge": true,
-  "labels": [
-    "dependencies"
-  ],
-  "rebaseWhen": "conflicted"
+  "automerge": true
 }


### PR DESCRIPTION
The change proposed moves the existing renovate config to our [parent config](https://github.com/jenkinsci/renovate-config) to ease maintenance.

Custom configurations, if available, are still effective.